### PR TITLE
ci: add Slack notification on build completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,99 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm test
+
+  notify:
+    name: Notify
+    needs: [test]
+    if: always() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+    steps:
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          TEST_RESULT: ${{ needs.test.result }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          GH_SERVER_URL: ${{ github.server_url }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_SHA: ${{ github.sha }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_ACTOR: ${{ github.actor }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ -z "$SLACK_WEBHOOK" ]]; then
+            echo "SLACK_WEBHOOK_URL not configured, skipping notification"
+            exit 0
+          fi
+
+          WORKFLOW_URL="${GH_SERVER_URL}/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}"
+          SHORT_SHA="${GH_SHA:0:7}"
+          COMMIT_URL="${GH_SERVER_URL}/${GH_REPOSITORY}/commit/${GH_SHA}"
+
+          TRIGGER="$GH_EVENT_NAME"
+          case "$TRIGGER" in
+            push)
+              if echo "$COMMIT_MESSAGE" | head -n1 | grep -q "Merge pull request"; then
+                TRIGGER_TEXT="PR merge"
+              else
+                TRIGGER_TEXT="Push"
+              fi
+              ;;
+            workflow_dispatch) TRIGGER_TEXT="Manual" ;;
+            *) TRIGGER_TEXT="$TRIGGER" ;;
+          esac
+
+          if [[ "$TEST_RESULT" == "success" ]]; then
+            COLOR="#36a64f"; EMOJI="white_check_mark"
+            HEADER="QURL TypeScript SDK Build"; STATUS_TEXT="successful"
+          elif [[ "$TEST_RESULT" == "failure" ]]; then
+            COLOR="#dc3545"; EMOJI="x"
+            HEADER="QURL TypeScript SDK Build"; STATUS_TEXT="failed"
+          elif [[ "$TEST_RESULT" == "cancelled" ]]; then
+            COLOR="#ffc107"; EMOJI="warning"
+            HEADER="QURL TypeScript SDK Build"; STATUS_TEXT="cancelled"
+          else
+            COLOR="#ffc107"; EMOJI="warning"
+            HEADER="QURL TypeScript SDK Build"; STATUS_TEXT="incomplete"
+          fi
+
+          case "$TEST_RESULT" in
+            success) TEST_EMOJI=":white_check_mark:" ;;
+            failure) TEST_EMOJI=":x:" ;;
+            *) TEST_EMOJI=":warning:" ;;
+          esac
+
+          FIRST_LINE=$(echo "$COMMIT_MESSAGE" | head -n1 | cut -c1-100)
+
+          PAYLOAD=$(jq -n \
+            --arg color "$COLOR" \
+            --arg emoji "$EMOJI" \
+            --arg header "$HEADER" \
+            --arg status "$STATUS_TEXT" \
+            --arg branch "$GH_REF_NAME" \
+            --arg sha "$SHORT_SHA" \
+            --arg trigger "$TRIGGER_TEXT" \
+            --arg actor "$GH_ACTOR" \
+            --arg test_emoji "$TEST_EMOJI" \
+            --arg commit "$FIRST_LINE" \
+            --arg commit_url "$COMMIT_URL" \
+            --arg workflow_url "$WORKFLOW_URL" \
+            '{attachments: [{color: $color, blocks: [
+              {type: "section", text: {type: "mrkdwn", text: (":\($emoji): *\($header)* \($status)")}},
+              {type: "section", fields: [
+                {type: "mrkdwn", text: ("*Branch:*\n`\($branch)` (\($sha))")},
+                {type: "mrkdwn", text: ("*Trigger:*\n\($trigger) by \($actor)")},
+                {type: "mrkdwn", text: ("*Tests:*\n\($test_emoji)")},
+                {type: "mrkdwn", text: "*Node:*\n22"}
+              ]},
+              {type: "section", text: {type: "mrkdwn", text: ("*Commit:* `\($commit)`")}},
+              {type: "context", elements: [
+                {type: "mrkdwn", text: ("<\($commit_url)|\($sha)>  |  <\($workflow_url)|View workflow>")}
+              ]}
+            ]}]}')
+
+          curl -sfS -X POST "$SLACK_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" || echo "Slack notification failed (non-critical)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
                 {type: "mrkdwn", text: ("*Branch:*\n`\($branch)` (\($sha))")},
                 {type: "mrkdwn", text: ("*Trigger:*\n\($trigger) by \($actor)")},
                 {type: "mrkdwn", text: ("*Tests:*\n\($test_emoji)")},
-                {type: "mrkdwn", text: "*Node:*\n22"}
+                {type: "mrkdwn", text: "*SDK:*\nTypeScript"}
               ]},
               {type: "section", text: {type: "mrkdwn", text: ("*Commit:* `\($commit)`")}},
               {type: "context", elements: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,7 @@ jobs:
           SHORT_SHA="${GH_SHA:0:7}"
           COMMIT_URL="${GH_SERVER_URL}/${GH_REPOSITORY}/commit/${GH_SHA}"
 
-          TRIGGER="$GH_EVENT_NAME"
-          case "$TRIGGER" in
+          case "$GH_EVENT_NAME" in
             push)
               if echo "$COMMIT_MESSAGE" | head -n1 | grep -q "Merge pull request"; then
                 TRIGGER_TEXT="PR merge"
@@ -63,8 +62,7 @@ jobs:
                 TRIGGER_TEXT="Push"
               fi
               ;;
-            workflow_dispatch) TRIGGER_TEXT="Manual" ;;
-            *) TRIGGER_TEXT="$TRIGGER" ;;
+            *) TRIGGER_TEXT="$GH_EVENT_NAME" ;;
           esac
 
           HEADER="QURL TypeScript SDK Build"
@@ -76,6 +74,7 @@ jobs:
           esac
 
           FIRST_LINE=$(echo "$COMMIT_MESSAGE" | head -n1 | cut -c1-100)
+          FIRST_LINE="${FIRST_LINE:-(no commit message)}"
 
           PAYLOAD=$(jq -n \
             --arg color "$COLOR" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -64,24 +67,12 @@ jobs:
             *) TRIGGER_TEXT="$TRIGGER" ;;
           esac
 
-          if [[ "$TEST_RESULT" == "success" ]]; then
-            COLOR="#36a64f"; EMOJI="white_check_mark"
-            HEADER="QURL TypeScript SDK Build"; STATUS_TEXT="successful"
-          elif [[ "$TEST_RESULT" == "failure" ]]; then
-            COLOR="#dc3545"; EMOJI="x"
-            HEADER="QURL TypeScript SDK Build"; STATUS_TEXT="failed"
-          elif [[ "$TEST_RESULT" == "cancelled" ]]; then
-            COLOR="#ffc107"; EMOJI="warning"
-            HEADER="QURL TypeScript SDK Build"; STATUS_TEXT="cancelled"
-          else
-            COLOR="#ffc107"; EMOJI="warning"
-            HEADER="QURL TypeScript SDK Build"; STATUS_TEXT="incomplete"
-          fi
-
+          HEADER="QURL TypeScript SDK Build"
           case "$TEST_RESULT" in
-            success) TEST_EMOJI=":white_check_mark:" ;;
-            failure) TEST_EMOJI=":x:" ;;
-            *) TEST_EMOJI=":warning:" ;;
+            success)  COLOR="#36a64f"; EMOJI=":white_check_mark:"; STATUS_TEXT="successful" ;;
+            failure)  COLOR="#dc3545"; EMOJI=":x:";                STATUS_TEXT="failed" ;;
+            cancelled) COLOR="#ffc107"; EMOJI=":warning:";         STATUS_TEXT="cancelled" ;;
+            *)        COLOR="#ffc107"; EMOJI=":warning:";          STATUS_TEXT="incomplete" ;;
           esac
 
           FIRST_LINE=$(echo "$COMMIT_MESSAGE" | head -n1 | cut -c1-100)
@@ -95,16 +86,15 @@ jobs:
             --arg sha "$SHORT_SHA" \
             --arg trigger "$TRIGGER_TEXT" \
             --arg actor "$GH_ACTOR" \
-            --arg test_emoji "$TEST_EMOJI" \
             --arg commit "$FIRST_LINE" \
             --arg commit_url "$COMMIT_URL" \
             --arg workflow_url "$WORKFLOW_URL" \
             '{attachments: [{color: $color, blocks: [
-              {type: "section", text: {type: "mrkdwn", text: (":\($emoji): *\($header)* \($status)")}},
+              {type: "section", text: {type: "mrkdwn", text: ("\($emoji) *\($header)* \($status)")}},
               {type: "section", fields: [
                 {type: "mrkdwn", text: ("*Branch:*\n`\($branch)` (\($sha))")},
                 {type: "mrkdwn", text: ("*Trigger:*\n\($trigger) by \($actor)")},
-                {type: "mrkdwn", text: ("*Tests:*\n\($test_emoji)")},
+                {type: "mrkdwn", text: ("*Tests:*\n\($emoji)")},
                 {type: "mrkdwn", text: "*SDK:*\nTypeScript"}
               ]},
               {type: "section", text: {type: "mrkdwn", text: ("*Commit:* `\($commit)`")}},


### PR DESCRIPTION
## Summary

Adds Slack build notifications to the CI workflow, matching the pattern established in qurl-python.

- Notifies on push-to-main only (not PRs)
- Uses `jq` for JSON payload construction (avoids shell escaping bugs — see layervai/qurl-python#15)
- Reports test status, branch, trigger, commit message
- Skips gracefully when `SLACK_WEBHOOK_URL` secret is not configured
- `continue-on-error: true` + `timeout-minutes: 5` — notification failure never blocks CI

## Prerequisites

The `SLACK_WEBHOOK_URL` secret must be configured in the repo settings. Until then, the job logs "not configured, skipping" and exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)