### PR TITLE
fix: use canonical /v1/qurls path for create (plural)

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -60,7 +60,7 @@ describe("QURLClient", () => {
     expect(result.resource_id).toBe("r_abc123def45");
     expect(result.qurl_link).toBe("https://qurl.link/#at_test");
     expect(fetch).toHaveBeenCalledWith(
-      "https://api.test.layerv.ai/v1/qurl",
+      "https://api.test.layerv.ai/v1/qurls",
       expect.objectContaining({ method: "POST" }),
     );
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -115,7 +115,7 @@ export class QURLClient {
 
   /** Create a new QURL. */
   async create(input: CreateInput): Promise<CreateOutput> {
-    return this.request<CreateOutput>("POST", "/v1/qurl", input);
+    return this.request<CreateOutput>("POST", "/v1/qurls", input);
   }
 
   /** Gets a protected URL and its access tokens. */


### PR DESCRIPTION
## Summary

SDK's `create()` at `src/client.ts:118` posted to `/v1/qurl` (singular) while every other SDK method (`get`, `list`, `update`, `delete`, `mintLink`) AND the qurl-service backend use `/v1/qurls` (plural). Singular would return 404 against the real service. The existing test at `src/client.test.ts:63` codified the bug by asserting the wrong URL, so it's updated in the same commit.

## Canonical path evidence

Plural `/v1/qurls` is canonical across qurl-service:
- `tests/smoke/headless_test.go:28,49,243,261,336,354` — all POST `/v1/qurls`
- `tests/smoke/session_duration_test.go` — ~15 occurrences of POST `/v1/qurls` + DELETE `/v1/qurls/{id}` + POST `/v1/qurls/{id}/mint_link`
- `tests/integration/api_test.go:190` — POST `/v1/qurls`
- `internal/api/middleware/idempotency_{dynamodb_,}test.go` — idempotency keys generated for POST `/v1/qurls`
- `cmd/qurl-schema-check/main.go:13` — comment explicitly references `POST /v1/qurls`

## Change

```diff
- return this.request<CreateOutput>("POST", "/v1/qurl", input);
+ return this.request<CreateOutput>("POST", "/v1/qurls", input);
```

```diff
-      "https://api.test.layerv.ai/v1/qurl",
+      "https://api.test.layerv.ai/v1/qurls",
```

## Test plan

- [x] `npm test` — all 48 vitest cases pass.
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [x] `grep -rn '/v1/qurl[^s]' src/` returns no hits.
- [ ] After merge: the next SDK consumer (qurl-discord-bot, once the ESM/CJS blocker is resolved) will hit the real create endpoint instead of 404.

## Rollback

Plain revert. No state, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)