### PR TITLE
test: add OpenAPI contract test snapshotting qurl-service paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,20 @@ SDK depends on, and the SDK needs to be updated in lockstep.
 method calls. Alias methods (e.g. `extend` → `update`) get their own
 case so an alias rewire can't silently slip past.
 
+**What the contract test does and does not catch:** the assertion is
+scoped to `(verb, path)` — it verifies the SDK hits the right endpoint.
+It does **not** verify request body field names, response envelope
+parsing, or query parameter names. Body/response shape drift is a
+separate class (would warrant an `ajv`-backed schema validation layer
+against the OpenAPI component schemas) and is intentionally out of scope
+here.
+
+**Reviewing a regenerated-snapshot PR:** the ~4400-line YAML produces
+noisy diffs on every regen. Reviewers should verify the source commit
+SHA in the snapshot header and trust `git show` provenance — scanning
+the YAML body line-by-line is not a useful exercise. The contract test
+failing is the real signal that an SDK-used endpoint changed upstream.
+
 ## Pull Requests
 
 1. Fork the repo and create a branch from `main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,11 @@ was last validated against. If the regenerated snapshot breaks the
 contract test, that's the signal: qurl-service changed an endpoint the
 SDK depends on, and the SDK needs to be updated in lockstep.
 
+**Adding a new public SDK method?** Add a matching case to
+`src/contract.test.ts` asserting the exact `(verb, path-template)` the
+method calls. Alias methods (e.g. `extend` → `update`) get their own
+case so an alias rewire can't silently slip past.
+
 ## Pull Requests
 
 1. Fork the repo and create a branch from `main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,29 @@ npx eslint src/        # Lint
 
 All must pass before submitting a PR.
 
+## OpenAPI Contract Snapshot
+
+`contract/openapi.snapshot.yaml` is a vendored copy of `api/openapi.yaml`
+from the [qurl-service](https://github.com/layervai/qurl-service) backend.
+The contract test (`src/contract.test.ts`) reads it to assert every SDK
+method calls the (verb, path) pair the backend actually exposes.
+
+Regenerate it when adopting a newer qurl-service release:
+
+```bash
+# Expects qurl-service checked out at ../qurl-service (sibling directory).
+# Override with: QURL_SERVICE_DIR=/path/to/qurl-service
+scripts/update-openapi-snapshot.sh               # defaults to origin/main
+scripts/update-openapi-snapshot.sh v1.2.3        # pin to a tag
+scripts/update-openapi-snapshot.sh <sha>         # pin to a specific commit
+```
+
+The script writes the resolved commit SHA into the snapshot header, so
+reviewers can see exactly which version of the backend contract the SDK
+was last validated against. If the regenerated snapshot breaks the
+contract test, that's the signal: qurl-service changed an endpoint the
+SDK depends on, and the SDK needs to be updated in lockstep.
+
 ## Pull Requests
 
 1. Fork the repo and create a branch from `main`

--- a/contract/openapi.snapshot.yaml
+++ b/contract/openapi.snapshot.yaml
@@ -1,0 +1,4403 @@
+# Snapshot of qurl-service/api/openapi.yaml — canonical API contract.
+# This file is vendored (not auto-generated) so the contract test runs
+# hermetically without network or cross-repo checkout.
+#
+# Source: layervai/qurl-service@2585c0e0adc2337e63b32596f943863159a88b1b
+# Regenerate with: scripts/update-openapi-snapshot.sh
+#
+# OpenAPI 3.0.3 is used instead of 3.1.0 for compatibility with oapi-codegen.
+# oapi-codegen v2.x does not fully support OpenAPI 3.1 features.
+openapi: 3.0.3
+info:
+  title: QURL Service API
+  description: |
+    API for managing QURL resources - secure, time-limited access links to protected resources.
+
+    ## Authentication
+    The public API requires Auth0 JWT tokens or API keys with appropriate scopes:
+    - `qurl:read` - Read access to QURLs and quota
+    - `qurl:write` - Create, update, and delete QURLs
+    - `qurl:resolve` - Resolve access tokens and trigger firewall access (headless)
+    - `qurl:write` also covers webhook management
+
+    ## Rate Limiting
+    - Per-owner: Configurable limit (default varies by plan)
+    - Per-IP: Configurable limit for internal endpoints
+
+    Rate limit exceeded responses include a `Retry-After` header.
+
+    ## Idempotency
+    Mutating endpoints (POST, PUT, PATCH) support idempotency via the `Idempotency-Key` header.
+    When provided, the response is cached and subsequent requests with the same key return
+    the cached response with `Idempotency-Replayed: true` header.
+
+    ## Response Envelope
+    All responses use a consistent envelope format:
+    ```json
+    {
+      "data": { ... },      // For success responses
+      "error": { ... },     // For error responses (RFC 7807 format)
+      "meta": {
+        "request_id": "...",
+        "page_size": 20,    // For list responses
+        "has_more": true,   // For list responses
+        "next_cursor": "..."// For list responses
+      }
+    }
+    ```
+
+    ## Error Responses (RFC 7807)
+    Error responses follow [RFC 7807 Problem Details](https://datatracker.ietf.org/doc/html/rfc7807)
+    with `Content-Type: application/problem+json`:
+    ```json
+    {
+      "error": {
+        "type": "https://api.qurl.link/problems/invalid_request",
+        "title": "Invalid Request",
+        "status": 400,
+        "detail": "The target_url field must be a valid HTTPS URL",
+        "instance": "/v1/qurls",
+        "code": "invalid_request"
+      },
+      "meta": { "request_id": "..." }
+    }
+    ```
+    For validation errors, an additional `invalid_fields` map is included.
+
+    ## Caching
+    GET endpoints support ETag-based caching. Include `If-None-Match` header with
+    the ETag value to receive a 304 Not Modified response when content hasn't changed.
+
+    ## Object Model
+
+    - **Resource** (`r_` prefix): Long-lived container grouped by target URL. Holds metadata
+      (tags, description, custom domain). Auto-created on first QURL for a target URL.
+    - **QURL / Access Token** (`q_` display ID, `at_` token): Short-lived, policy-bound access
+      token. Belongs to one Resource. Owns expiry, access policy, session limits.
+    - **Access Link**: The `qurl.link/at_xxx` URL returned once at creation time.
+
+    The `/v1/qurls` endpoints are resource-centric — `{id}` accepts both resource IDs (`r_`)
+    and QURL display IDs (`q_`). Per-QURL management uses
+    `DELETE /v1/resources/{id}/qurls/{qurl_id}` to revoke individual tokens.
+
+    ## Webhooks
+    Subscribe to events via webhook endpoints. Webhook payloads are signed with
+    HMAC-SHA256 using your webhook secret. Verify the `QURL-Signature` header.
+  version: 1.0.0
+  contact:
+    name: LayerV
+    url: https://layerv.ai
+
+servers:
+  - url: https://api.layerv.ai
+    description: Production
+  - url: https://api.layerv.xyz
+    description: Sandbox
+
+security:
+  - bearerAuth: []
+
+tags:
+  - name: QURLs
+    description: QURL resource management
+  - name: Quota
+    description: Usage quota information
+  - name: Webhooks
+    description: Webhook endpoint management
+  - name: API Keys
+    description: API key management (JWT-only, API keys cannot manage API keys)
+  - name: Usage
+    description: Usage and billing period information (JWT-only)
+  - name: Customer
+    description: Customer profile and billing settings (JWT-only)
+  - name: Billing
+    description: Stripe checkout, portal, and invoices (JWT-only)
+  - name: Resolution
+    description: Headless QURL resolution for AI agents and programmatic clients
+  - name: Domains
+    description: Custom domain management (enterprise plan)
+  - name: Access Codes
+    description: Access code management for protected resource sharing
+  - name: Resources
+    description: Resource management (dashboard-only, groups QURLs by target URL)
+
+paths:
+  /v1/resolve:
+    post:
+      tags:
+        - Resolution
+      summary: Resolve a QURL access token (headless)
+      description: |
+        Resolves a QURL access token and triggers an NHP knock to open firewall access
+        for the caller's IP address. Returns the target URL that the caller can access
+        directly for the duration of the access grant.
+
+        This endpoint is designed for AI agents and programmatic clients that cannot
+        follow the browser-based QURL flow.
+
+        **Important:** The firewall is opened for the IP address making this request.
+        The `src_ip` in the response reflects which IP was granted access.
+
+        **One-time tokens:** If the token is one-time-use and the NHP knock fails after
+        token resolution, the token is consumed but no access is granted. Multi-use
+        tokens can be retried.
+      operationId: resolveQurl
+      security:
+        - bearerAuth: [qurl:resolve]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResolveQurlRequest'
+            example:
+              access_token: "at_k8xqp9h2sj9lx7r4abcdef"
+      responses:
+        '200':
+          description: Token resolved and firewall access granted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResolveQurlResponse'
+              example:
+                data:
+                  target_url: "https://api.example.com/data"
+                  resource_id: "r_k8xqp9h2sj9"
+                  access_grant:
+                    expires_in: 305
+                    granted_at: "2026-03-09T15:30:00Z"
+                    src_ip: "203.0.113.42"
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '410':
+          $ref: '#/components/responses/Gone'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '502':
+          $ref: '#/components/responses/BadGateway'
+
+  /v1/qurls:
+    post:
+      tags:
+        - QURLs
+      summary: Create a new QURL
+      description: |
+        Creates a QURL access token for a target URL. Auto-creates a resource
+        if none exists for the target URL.
+      operationId: createQurl
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateQurlRequest'
+            example:
+              target_url: "https://internal.example.com/dashboard"
+              expires_in: "7d"
+              one_time_use: false
+              max_sessions: 5
+              description: "Admin dashboard access for external contractor"
+              metadata:
+                customer_id: "cust_123"
+                ticket: "JIRA-456"
+              access_policy:
+                ip_allowlist: ["192.168.1.0/24"]
+                geo_allowlist: ["US", "CA"]
+                ai_agent_policy:
+                  deny_categories: ["gptbot", "commoncrawl", "bytedance"]
+      responses:
+        '201':
+          description: QURL created successfully
+          headers:
+            Location:
+              description: URL of the created QURL resource
+              schema:
+                type: string
+                format: uri
+                example: "https://api.qurl.link/v1/qurls/r_k8xqp9h2sj9"
+            Idempotency-Replayed:
+              description: Present and set to "true" if response was replayed from cache
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateQurlResponse'
+              example:
+                data:
+                  resource_id: "r_k8xqp9h2sj9"
+                  qurl_link: "https://qurl.link/at_abc123def456ghi789"
+                  qurl_site: "https://r_k8xqp9h2sj9.qurl.site"
+                  expires_at: "2024-01-15T10:30:00Z"
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    get:
+      tags:
+        - QURLs
+      summary: List QURLs
+      description: |
+        Lists resources owned by the authenticated user. Each resource groups
+        QURLs sharing the same target URL.
+        Supports filtering by status and date ranges, with cursor-based pagination.
+      operationId: listQurls
+      security:
+        - bearerAuth: [qurl:read]
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of results to return (1-100)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: cursor
+          in: query
+          description: |
+            Pagination cursor from previous response.
+            Changing the sort parameter resets pagination to the first page.
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Filter by status (comma-separated for multiple)
+          schema:
+            type: string
+            example: "active,revoked"
+        - name: created_after
+          in: query
+          description: Filter by creation date (RFC3339)
+          schema:
+            type: string
+            format: date-time
+        - name: created_before
+          in: query
+          description: Filter by creation date (RFC3339)
+          schema:
+            type: string
+            format: date-time
+        - name: expires_before
+          in: query
+          description: Filter by expiration date (RFC3339)
+          schema:
+            type: string
+            format: date-time
+        - name: expires_after
+          in: query
+          description: Filter by expiration date (RFC3339)
+          schema:
+            type: string
+            format: date-time
+        - name: sort
+          in: query
+          description: |
+            Sort field and direction (field:direction).
+            Valid fields: created_at, expires_at.
+            Direction: asc or desc (default: desc).
+            Sort order is consistent across pages.
+          schema:
+            type: string
+            example: "created_at:desc"
+        - name: q
+          in: query
+          description: |
+            Search query string (case-insensitive).
+            Searches across description and target_url fields.
+          schema:
+            type: string
+            maxLength: 200
+            example: "dashboard"
+      responses:
+        '200':
+          description: List of QURLs
+          headers:
+            ETag:
+              description: Entity tag for caching
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QurlListResponse'
+              example:
+                data:
+                  - resource_id: "r_k8xqp9h2sj9"
+                    target_url: "https://internal.example.com/dashboard"
+                    status: "active"
+                    created_at: "2024-01-08T10:30:00Z"
+                    expires_at: "2024-01-15T10:30:00Z"
+                    description: "Admin dashboard access"
+                    qurl_site: "https://r_k8xqp9h2sj9.qurl.site"
+                  - resource_id: "r_lm2np4q8rt7"
+                    target_url: "https://api.example.com/reports"
+                    status: "active"
+                    created_at: "2024-01-07T14:00:00Z"
+                    expires_at: "2024-01-14T14:00:00Z"
+                    qurl_site: "https://r_lm2np4q8rt7.qurl.site"
+                meta:
+                  request_id: "req_abc123"
+                  page_size: 2
+                  has_more: true
+                  next_cursor: "eyJyIjoicl9MbTJOcDRROHJUNyJ9"
+        '304':
+          description: Not Modified (ETag match)
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/qurls/{id}:
+    get:
+      tags:
+        - QURLs
+      summary: Get a QURL
+      description: Retrieves a resource and its QURL tokens by resource or QURL display ID.
+      operationId: getQurl
+      security:
+        - bearerAuth: [qurl:read]
+      parameters:
+        - $ref: '#/components/parameters/QurlId'
+      responses:
+        '200':
+          description: QURL details
+          headers:
+            ETag:
+              description: Entity tag for caching
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QurlResponse'
+              example:
+                data:
+                  resource_id: "r_k8xqp9h2sj9"
+                  target_url: "https://internal.example.com/dashboard"
+                  status: "active"
+                  created_at: "2024-01-08T10:30:00Z"
+                  expires_at: "2024-01-15T10:30:00Z"
+                  description: "Admin dashboard access"
+                  qurl_site: "https://r_k8xqp9h2sj9.qurl.site"
+                meta:
+                  request_id: "req_abc123"
+        '304':
+          description: Not Modified (ETag match)
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    delete:
+      tags:
+        - QURLs
+      summary: Delete a QURL
+      description: |
+        Revokes a resource and all its QURLs. Requires a resource ID (r_ prefix).
+        To revoke a single token, use DELETE /v1/resources/{resource_id}/qurls/{qurl_id}.
+      operationId: deleteQurl
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/QurlId'
+      responses:
+        '204':
+          description: QURL deleted successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    patch:
+      tags:
+        - QURLs
+      summary: Update a QURL
+      description: Updates resource-level metadata (description, tags, expiration).
+      operationId: updateQurl
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/QurlId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateQurlRequest'
+            examples:
+              relative:
+                summary: Extend by relative duration
+                value:
+                  extend_by: "7d"
+              absolute:
+                summary: Set absolute expiration
+                value:
+                  expires_at: "2024-01-22T10:30:00Z"
+      responses:
+        '200':
+          description: QURL updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QurlResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/qurls/{id}/mint_link:
+    post:
+      tags:
+        - QURLs
+      summary: Mint an access link
+      description: |
+        Creates a new QURL access token for an existing resource.
+        The link can be shared with users who need temporary access to the resource.
+      operationId: mintLink
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/QurlId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MintLinkRequest'
+            example:
+              expires_at: "2024-01-10T10:30:00Z"
+      responses:
+        '201':
+          description: Access link created
+          headers:
+            Location:
+              description: The minted access link URL
+              schema:
+                type: string
+                format: uri
+                example: "https://qurl.link/at_xyz789abc123def456"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MintLinkResponse'
+              example:
+                data:
+                  qurl_link: "https://qurl.link/at_xyz789abc123def456"
+                  expires_at: "2024-01-10T10:30:00Z"
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/qurls/batch:
+    post:
+      tags:
+        - QURLs
+      summary: Batch create QURLs
+      description: |
+        Creates multiple QURL resources in a single request.
+        Returns 201 if all succeed, 207 Multi-Status if mixed results, or 400 if all fail.
+
+        **Validation is atomic:** if any item fails input validation (e.g. invalid tags,
+        description too long), the entire batch is rejected with per-item error details.
+        Items that passed validation are marked as "skipped" in the results.
+      operationId: batchCreateQurls
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchCreateRequest'
+            example:
+              items:
+                - target_url: "https://app1.example.com"
+                  expires_in: "7d"
+                  access_policy:
+                    ai_agent_policy:
+                      allow_categories: ["claude", "perplexity"]
+                - target_url: "https://app2.example.com"
+                  expires_in: "24h"
+                  one_time_use: true
+      responses:
+        '201':
+          description: All QURLs created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchCreateResponse'
+              example:
+                data:
+                  succeeded: 2
+                  failed: 0
+                  results:
+                    - index: 0
+                      success: true
+                      resource_id: "r_k8xqp9h2sj9"
+                      qurl_link: "https://qurl.link/at_abc123"
+                      qurl_site: "https://r_k8xqp9h2sj9.qurl.site"
+                      expires_at: "2024-01-15T10:30:00Z"
+                    - index: 1
+                      success: true
+                      resource_id: "r_lm2np4q8rt7"
+                      qurl_link: "https://qurl.link/at_def456"
+                      qurl_site: "https://r_lm2np4q8rt7.qurl.site"
+                      expires_at: "2024-01-09T10:30:00Z"
+                meta:
+                  request_id: "req_abc123"
+        '207':
+          description: Mixed results (some succeeded, some failed)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchCreateResponse'
+              example:
+                data:
+                  succeeded: 1
+                  failed: 1
+                  results:
+                    - index: 0
+                      success: true
+                      resource_id: "r_k8xqp9h2sj9"
+                      qurl_link: "https://qurl.link/at_abc123"
+                      qurl_site: "https://r_k8xqp9h2sj9.qurl.site"
+                      expires_at: "2024-01-15T10:30:00Z"
+                    - index: 1
+                      success: false
+                      error:
+                        code: "invalid_target_url"
+                        message: "target_url must be a valid HTTPS URL"
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          description: All items failed or invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchCreateResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/resources:
+    get:
+      tags:
+        - Resources
+      summary: List resources
+      description: |
+        Lists all resources (target URL groupings) for the authenticated user.
+        Each resource groups QURLs that share the same target URL. The response
+        includes a `qurl_count` for each resource showing how many active QURLs
+        exist for it. Use GET /v1/resources/{id} to see the individual QURLs.
+      operationId: listResources
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: cursor
+          in: query
+          description: Pagination cursor from a previous response
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of items to return (1-100, default 20)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: Resource list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Resources
+      summary: Create resource
+      description: |
+        Explicitly create a resource (register a target URL before creating
+        QURLs for it). If a resource already exists for the same target URL
+        and owner, the existing resource is returned (idempotent).
+      operationId: createResource
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateResourceRequest'
+      responses:
+        '201':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/resources/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Resource ID
+        schema:
+          type: string
+          pattern: '^r_[a-z0-9_-]{11}$'
+    get:
+      tags:
+        - Resources
+      summary: Get resource details
+      description: |
+        Get resource details including all QURLs associated with it.
+        Each QURL has its own label, expiry, access policy, and NHP
+        firewall rules — independent of other QURLs on the same resource.
+      operationId: getResource
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Resource details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceDetailResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      tags:
+        - Resources
+      summary: Update resource metadata
+      description: Update resource metadata (tags, description, custom_domain).
+      operationId: updateResource
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateResourceRequest'
+      responses:
+        '200':
+          description: Resource updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Resources
+      summary: Revoke resource and all its QURLs
+      description: |
+        Revokes a resource. All QURLs associated with the resource become
+        inaccessible because token resolution checks the resource status.
+      operationId: deleteResource
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Resource revoked
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/resources/{id}/qurls/{qurl_id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Resource ID
+        schema:
+          type: string
+          pattern: '^r_[a-z0-9_-]{11}$'
+      - name: qurl_id
+        in: path
+        required: true
+        description: QURL display ID (q_ + 11 hex chars)
+        schema:
+          type: string
+          pattern: '^q_[0-9a-f]{11}$'
+    delete:
+      tags:
+        - Resources
+      summary: Revoke a specific QURL
+      description: |
+        Revokes a specific QURL token. The QURL must be active. Other QURLs
+        on the same resource are not affected.
+      operationId: revokeResourceQurl
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: QURL revoked
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: QURL is not active
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      tags:
+        - Resources
+      summary: Update a specific QURL
+      description: |
+        Update expiry, label, access policy, or max_sessions on a specific QURL token.
+        The QURL must be active. At least one field must be provided.
+      operationId: updateResourceQurl
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateQurlTokenRequest'
+      responses:
+        '200':
+          description: QURL updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QurlSummaryResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: QURL is not active
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/resources/{id}/sessions:
+    get:
+      tags:
+        - Sessions
+      operationId: listResourceSessions
+      summary: List active sessions for a resource
+      description: Returns all active access sessions for the specified resource.
+      security:
+        - bearerAuth: []
+        - apiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Active sessions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Sessions
+      operationId: terminateAllResourceSessions
+      summary: Terminate all active sessions for a resource
+      description: Immediately terminates all active sessions for the specified resource.
+      security:
+        - bearerAuth: []
+        - apiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Sessions terminated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionTerminateResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/resources/{id}/sessions/{session_id}:
+    delete:
+      tags:
+        - Sessions
+      operationId: terminateResourceSession
+      summary: Terminate a specific session
+      description: Immediately terminates a specific active session.
+      security:
+        - bearerAuth: []
+        - apiKeyAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: session_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Session terminated
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/quota:
+    get:
+      tags:
+        - Quota
+      summary: Get quota information
+      description: Retrieves usage quota for the authenticated user.
+      operationId: getQuota
+      security:
+        - bearerAuth: [qurl:read]
+      responses:
+        '200':
+          description: Quota information
+          headers:
+            ETag:
+              description: Entity tag for caching
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuotaResponse'
+              example:
+                data:
+                  plan: "growth"
+                  period_start: "2024-01-01T00:00:00Z"
+                  period_end: "2024-02-01T00:00:00Z"
+                  rate_limits:
+                    create_per_minute: 200
+                    create_per_hour: 10000
+                    list_per_minute: 120
+                    resolve_per_minute: 300
+                    max_active_qurls: 1000
+                    max_tokens_per_qurl: 50
+                    max_expiry_seconds: 2592000
+                  usage:
+                    qurls_created: 150
+                    active_qurls: 45
+                    active_qurls_percent: 0.45
+                    total_accesses: 1250
+                meta:
+                  request_id: "req_abc123"
+        '304':
+          description: Not Modified (ETag match)
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/usage/current-period:
+    get:
+      tags:
+        - Usage
+      summary: Get current billing period usage
+      description: |
+        Returns usage statistics for the current billing period, including
+        the number of QURLs created, the user's tier, period dates, and a
+        cost estimate for usage-based plans (Growth tier).
+        Requires JWT authentication (dashboard endpoint).
+      operationId: getUsageCurrentPeriod
+      security:
+        - bearerAuth: [qurl:read]
+      responses:
+        '200':
+          description: Current period usage information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageCurrentPeriodResponse'
+              example:
+                data:
+                  tier: "growth"
+                  period_start: "2026-03-01T00:00:00Z"
+                  period_end: "2026-03-31T23:59:59Z"
+                  qurls_created: 150
+                  active_qurls: 45
+                  cost_estimate:
+                    currency: "usd"
+                    amount_cents: 1500
+                    description: "150 QURLs x $0.10/QURL"
+                meta:
+                  request_id: "req_abc123"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/usage/daily:
+    get:
+      tags:
+        - Usage
+      summary: Get daily usage breakdown
+      description: |
+        Returns a daily breakdown of QURL creation counts for the current
+        billing period. Intended for dashboard chart rendering.
+        Requires JWT authentication (dashboard endpoint).
+      operationId: getUsageDaily
+      security:
+        - bearerAuth: [qurl:read]
+      responses:
+        '200':
+          description: Daily usage breakdown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsageDailyResponse'
+              example:
+                data:
+                  tier: "growth"
+                  period_start: "2026-03-01T00:00:00Z"
+                  period_end: "2026-03-31T23:59:59Z"
+                  daily:
+                    - date: "2026-03-01"
+                      qurls_created: 12
+                    - date: "2026-03-02"
+                      qurls_created: 8
+                    - date: "2026-03-03"
+                      qurls_created: 15
+                meta:
+                  request_id: "req_abc123"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/customer:
+    get:
+      tags:
+        - Customer
+      summary: Get customer profile
+      description: |
+        Returns the authenticated user's customer profile including tier,
+        spending cap, usage count, and frozen status.
+        Creates a free-tier record on first access (lazy provisioning).
+        Requires JWT authentication (dashboard endpoint). API key authentication is not supported.
+      operationId: getCustomer
+      security:
+        - bearerAuth: [qurl:read]
+      responses:
+        '200':
+          description: Customer profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerResponse'
+              example:
+                data:
+                  tier: "growth"
+                  spending_cap_cents: 5000
+                  current_period_usage: 42
+                  frozen: false
+                meta:
+                  request_id: "req_abc123"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      tags:
+        - Customer
+      summary: Update customer settings
+      description: |
+        Updates customer settings. Currently supports spending cap.
+        Requires JWT authentication and growth or enterprise tier. API key authentication is not supported.
+      operationId: updateCustomer
+      security:
+        - bearerAuth: [qurl:write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCustomerRequest'
+      responses:
+        '200':
+          description: Updated customer profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/billing/checkout:
+    post:
+      tags:
+        - Billing
+      summary: Create Stripe checkout session
+      description: |
+        Creates a Stripe Checkout session for plan upgrade.
+        Returns a URL to redirect the user to Stripe's hosted checkout page.
+        Requires JWT authentication (dashboard endpoint). API key authentication is not supported.
+
+        The `plan` field selects which paid plan to check out into.
+        Only purchasable plans are permitted (currently: `growth`); any
+        other value is rejected with 400.
+      operationId: createBillingCheckout
+      security:
+        - bearerAuth: [qurl:write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateBillingCheckoutRequest'
+            example:
+              plan: "growth"
+      responses:
+        '200':
+          description: Checkout session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckoutSessionResponse'
+              example:
+                data:
+                  url: "https://checkout.stripe.com/c/pay/cs_test_..."
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+  /v1/billing/portal:
+    post:
+      tags:
+        - Billing
+      summary: Create Stripe billing portal session
+      description: |
+        Creates a Stripe Billing Portal session for managing subscriptions,
+        payment methods, and invoices. Returns a URL to redirect the user.
+        Requires JWT authentication (dashboard endpoint). API key authentication is not supported.
+      operationId: createBillingPortal
+      security:
+        - bearerAuth: [qurl:write]
+      responses:
+        '200':
+          description: Portal session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortalSessionResponse'
+              example:
+                data:
+                  url: "https://billing.stripe.com/p/session/..."
+                meta:
+                  request_id: "req_abc123"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+  /v1/billing/invoices:
+    get:
+      tags:
+        - Billing
+      summary: List invoices
+      description: |
+        Returns the authenticated user's Stripe invoices.
+        Requires JWT authentication (dashboard endpoint). API key authentication is not supported.
+      operationId: listBillingInvoices
+      security:
+        - bearerAuth: [qurl:read]
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of invoices to return (default 25, max 100)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 25
+        - name: cursor
+          in: query
+          description: Pagination cursor from previous response
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Invoice list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoiceListResponse'
+              example:
+                data:
+                  invoices:
+                    - id: "in_1234"
+                      amount_cents: 1500
+                      status: "paid"
+                      created_at: "2026-02-01T00:00:00Z"
+                      pdf_url: "https://pay.stripe.com/invoice/..."
+                meta:
+                  request_id: "req_abc123"
+                  has_more: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+  /v1/domains:
+    post:
+      tags:
+        - Domains
+      summary: Register a custom domain
+      description: |
+        Registers a new custom domain for the authenticated user.
+        Returns DNS records that must be configured before verification.
+        Requires enterprise plan.
+      operationId: registerDomain
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterDomainRequest'
+      responses:
+        '201':
+          description: Domain registered successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DomainResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: Domain already registered
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    get:
+      tags:
+        - Domains
+      summary: List domains
+      description: Lists custom domains for the authenticated user.
+      operationId: listDomains
+      security:
+        - bearerAuth: [qurl:read]
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of domains to return per page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: cursor
+          in: query
+          description: Pagination cursor from previous response
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of domains
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DomainListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/domains/{domain}:
+    get:
+      tags:
+        - Domains
+      summary: Get domain status
+      description: Retrieves the status and DNS configuration for a custom domain.
+      operationId: getDomain
+      security:
+        - bearerAuth: [qurl:read]
+      parameters:
+        - $ref: '#/components/parameters/DomainName'
+      responses:
+        '200':
+          description: Domain details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DomainResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Domains
+      summary: Remove domain
+      description: Removes a custom domain registration.
+      operationId: deleteDomain
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/DomainName'
+      responses:
+        '204':
+          description: Domain removed successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/domains/{domain}/verify:
+    post:
+      tags:
+        - Domains
+      summary: Trigger DNS verification
+      description: |
+        Triggers DNS verification for a custom domain.
+        Checks TXT record, ACME CNAME, and traffic routing configuration.
+      operationId: verifyDomain
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/DomainName'
+      responses:
+        '200':
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DomainVerifyResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Verification token has expired — use POST /v1/domains/{domain}/regenerate-token to get a new one
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/domains/{domain}/regenerate-token:
+    post:
+      tags:
+        - Domains
+      summary: Regenerate verification token
+      description: |
+        Regenerates the DNS verification token for a custom domain. The previous
+        token is invalidated immediately. A new TXT record must be configured
+        with the returned token before calling the verify endpoint.
+
+        Only allowed for domains in `pending_verification` or `failed` status.
+        The new token expires after 7 days.
+      operationId: regenerateToken
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/DomainName'
+      responses:
+        '200':
+          description: Token regenerated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DomainResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Token regeneration not allowed for current domain status
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/webhooks:
+    get:
+      tags:
+        - Webhooks
+      summary: List webhooks
+      description: Lists webhook endpoints owned by the authenticated user.
+      operationId: listWebhooks
+      security:
+        - bearerAuth: [qurl:read]
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of webhooks to return per page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: cursor
+          in: query
+          description: Pagination cursor from previous response
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of webhooks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookListResponse'
+              example:
+                data:
+                  - webhook_id: "wh_abc123def456ghij"
+                    url: "https://example.com/webhooks/qurl"
+                    events: ["qurl.created", "qurl.accessed"]
+                    status: "active"
+                    created_at: "2024-01-01T10:00:00Z"
+                    updated_at: "2024-01-01T10:00:00Z"
+                    failure_count: 0
+                    last_delivery_success: true
+                meta:
+                  request_id: "req_abc123"
+                  page_size: 1
+                  has_more: false
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    post:
+      tags:
+        - Webhooks
+      summary: Create a webhook
+      description: |
+        Creates a new webhook endpoint. The secret is returned only once in the response.
+        Store it securely - it cannot be retrieved later (only regenerated).
+      operationId: createWebhook
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateWebhookRequest'
+            example:
+              url: "https://example.com/webhooks/qurl"
+              events: ["qurl.created", "qurl.accessed", "qurl.revoked"]
+              description: "Production webhook for QURL events"
+      responses:
+        '201':
+          description: Webhook created successfully
+          headers:
+            Location:
+              description: URL of the created webhook resource
+              schema:
+                type: string
+                format: uri
+                example: "https://api.qurl.link/v1/webhooks/wh_abc123def456ghij"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookResponseWithSecret'
+              example:
+                data:
+                  webhook_id: "wh_abc123def456ghij"
+                  url: "https://example.com/webhooks/qurl"
+                  secret: "whsec_K8xQp9H2sJ9Lx7R4AaBbCcDdEeFf..."
+                  events: ["qurl.created", "qurl.accessed", "qurl.revoked"]
+                  status: "active"
+                  description: "Production webhook for QURL events"
+                  created_at: "2024-01-08T10:30:00Z"
+                  updated_at: "2024-01-08T10:30:00Z"
+                  failure_count: 0
+                  last_delivery_success: false
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      callbacks:
+        onEvent:
+          '{$request.body#/url}':
+            post:
+              summary: Webhook event delivery
+              description: |
+                Event payload delivered to your webhook URL.
+                Verify authenticity using the QURL-Signature header with HMAC-SHA256.
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/WebhookPayload'
+              responses:
+                '200':
+                  description: Event received successfully
+
+  /v1/webhooks/events:
+    get:
+      tags:
+        - Webhooks
+      summary: List available event types
+      description: Returns all available webhook event types with descriptions.
+      operationId: listWebhookEventTypes
+      security:
+        - bearerAuth: [qurl:read]
+      responses:
+        '200':
+          description: List of event types
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookEventTypesResponse'
+              example:
+                data:
+                  - type: "qurl.created"
+                    category: "resource"
+                    description: "A new QURL was created"
+                  - type: "qurl.accessed"
+                    category: "access"
+                    description: "A QURL was successfully accessed"
+                  - type: "qurl.access_denied"
+                    category: "access"
+                    description: "Access to a QURL was denied by policy"
+                  - type: "quota.exceeded"
+                    category: "quota"
+                    description: "Quota limit reached, action blocked"
+                meta:
+                  request_id: "req_abc123"
+
+  /v1/webhooks/{id}:
+    get:
+      tags:
+        - Webhooks
+      summary: Get a webhook
+      description: Retrieves a single webhook by ID.
+      operationId: getWebhook
+      security:
+        - bearerAuth: [qurl:read]
+      parameters:
+        - $ref: '#/components/parameters/WebhookId'
+      responses:
+        '200':
+          description: Webhook details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    patch:
+      tags:
+        - Webhooks
+      summary: Update a webhook
+      description: Updates a webhook's configuration.
+      operationId: updateWebhook
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/WebhookId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateWebhookRequest'
+            example:
+              events: ["qurl.created", "qurl.accessed", "qurl.revoked", "token.minted"]
+              status: "active"
+      responses:
+        '200':
+          description: Webhook updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    delete:
+      tags:
+        - Webhooks
+      summary: Delete a webhook
+      description: Deletes a webhook endpoint.
+      operationId: deleteWebhook
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/WebhookId'
+      responses:
+        '204':
+          description: Webhook deleted successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/webhooks/{id}/secret:
+    post:
+      tags:
+        - Webhooks
+      summary: Regenerate webhook secret
+      description: |
+        Regenerates the signing secret for a webhook. The old secret is immediately
+        invalidated. The new secret is returned only once - store it securely.
+      operationId: regenerateWebhookSecret
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/WebhookId'
+      responses:
+        '200':
+          description: Secret regenerated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookResponseWithSecret'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/webhooks/{id}/deliveries:
+    get:
+      tags:
+        - Webhooks
+      summary: List webhook deliveries
+      description: Lists recent delivery attempts for a webhook.
+      operationId: listWebhookDeliveries
+      security:
+        - bearerAuth: [qurl:read]
+      parameters:
+        - $ref: '#/components/parameters/WebhookId'
+        - name: limit
+          in: query
+          description: Maximum number of deliveries to return per page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: cursor
+          in: query
+          description: Pagination cursor from previous response
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of delivery attempts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WebhookDeliveryListResponse'
+              example:
+                data:
+                  - delivery_id: "wd_abc123def456ghij"
+                    webhook_id: "wh_abc123def456ghij"
+                    event_type: "qurl.accessed"
+                    status: "success"
+                    response_code: 200
+                    duration_ms: 145
+                    retry_count: 0
+                    created_at: "2024-01-08T10:35:00Z"
+                    completed_at: "2024-01-08T10:35:00Z"
+                meta:
+                  request_id: "req_abc123"
+                  page_size: 1
+                  has_more: false
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/api-keys:
+    post:
+      tags:
+        - API Keys
+      summary: Create a new API key
+      description: |
+        Creates a new API key for the authenticated user.
+        The plaintext API key is returned only once in the response - store it securely.
+        Requires JWT authentication (API keys cannot create API keys).
+      operationId: createApiKey
+      security:
+        - bearerAuth: [qurl:write]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateApiKeyRequest'
+            example:
+              name: "Production integration"
+              scopes: ["qurl:read", "qurl:write"]
+      responses:
+        '201':
+          description: API key created successfully
+          headers:
+            Location:
+              description: URL of the created API key resource
+              schema:
+                type: string
+                format: uri
+                example: "https://api.qurl.link/v1/api-keys/key_abc123def456"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateApiKeyResponse'
+              example:
+                data:
+                  key_id: "key_abc123def456"
+                  api_key: "lv_live_a3x9Kp2mN8qR5sT7wY0zBcDfGhJkLmNp"
+                  key_prefix: "lv_live_a3x9"
+                  name: "Production integration"
+                  scopes: ["qurl:read", "qurl:write"]
+                  status: "active"
+                  created_at: "2024-01-08T10:30:00Z"
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: |
+            Forbidden. Either:
+            - API key auth was used (JWT required for key management), or
+            - Plan key limit reached (free: 3, growth: 50). Error code: `api_key_limit`.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    get:
+      tags:
+        - API Keys
+      summary: List API keys
+      description: |
+        Lists API keys owned by the authenticated user.
+        The plaintext API key is never returned in list responses.
+        Requires JWT authentication (API keys cannot list API keys).
+      operationId: listApiKeys
+      security:
+        - bearerAuth: [qurl:read]
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of results to return (1-100)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: cursor
+          in: query
+          description: Pagination cursor from previous response
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Filter by key status. Defaults to "active" to exclude revoked keys.
+          schema:
+            type: string
+            enum: [active, revoked, all]
+            default: active
+      responses:
+        '200':
+          description: List of API keys
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyListResponse'
+              example:
+                data:
+                  - key_id: "key_abc123def456"
+                    key_prefix: "lv_live_a3x9"
+                    name: "Production integration"
+                    scopes: ["qurl:read", "qurl:write"]
+                    status: "active"
+                    created_at: "2024-01-08T10:30:00Z"
+                    last_used_at: "2024-01-10T14:22:00Z"
+                meta:
+                  request_id: "req_abc123"
+                  page_size: 1
+                  has_more: false
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/api-keys/{key_id}:
+    patch:
+      tags:
+        - API Keys
+      summary: Update an API key
+      description: |
+        Updates the name or scopes of an existing API key.
+        Requires JWT authentication (API keys cannot update API keys).
+        If neither name nor scopes are provided, the existing key is returned unchanged (no-op).
+      operationId: updateApiKey
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - name: key_id
+          in: path
+          required: true
+          description: API key identifier
+          schema:
+            type: string
+            pattern: '^key_[A-Za-z0-9]{12}$'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateApiKeyRequest'
+            example:
+              name: "Updated key name"
+              scopes: ["qurl:read"]
+      responses:
+        '200':
+          description: API key updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiKeyResponse'
+              example:
+                data:
+                  key_id: "key_abc123def456"
+                  key_prefix: "lv_live_a3x9"
+                  name: "Updated key name"
+                  scopes: ["qurl:read"]
+                  status: "active"
+                  created_at: "2024-01-08T10:30:00Z"
+                  last_used_at: "2024-01-10T14:22:00Z"
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - API Keys
+      summary: Revoke an API key
+      description: |
+        Revokes an API key (soft delete). The key status is set to "revoked"
+        and a TTL is set for automatic cleanup after 30 days.
+        Requires JWT authentication (API keys cannot revoke API keys).
+      operationId: revokeApiKey
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - name: key_id
+          in: path
+          required: true
+          description: API key identifier
+          schema:
+            type: string
+            pattern: '^key_[A-Za-z0-9]{12}$'
+      responses:
+        '204':
+          description: API key revoked successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/access-codes/redeem:
+    post:
+      tags:
+        - Access Codes
+      summary: Redeem an access code
+      description: |
+        Redeems an access code to obtain a time-limited access link to a protected resource.
+        This endpoint is public and does not require authentication.
+
+        The response contains a redirect URL. The client should redirect the user to this URL
+        to complete resource access.
+
+        Bot protection is applied: submissions with a non-empty honeypot field or elapsed time
+        under 3 seconds receive a fake success response.
+      operationId: redeemAccessCode
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RedeemAccessCodeRequest'
+            example:
+              code: "ac_k8xqp9h2sj9lx7r4abcdef"
+              honeypot: ""
+              elapsed_ms: 5200
+      responses:
+        '200':
+          description: Access code redeemed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedeemAccessCodeResponse'
+              example:
+                data:
+                  redirect_url: "https://qurl.link/#at_k8xqp9h2sj9lx7r4abcdef"
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/access-codes:
+    post:
+      tags:
+        - Access Codes
+      summary: Create an access code
+      description: |
+        Creates a new access code for a QURL resource. The plaintext code is returned only
+        once in the response - store it securely.
+
+        Requires system-tier account. The resource must exist and be owned by the authenticated user.
+      operationId: createAccessCode
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAccessCodeRequest'
+            example:
+              resource_id: "r_k8xqp9h2sj9"
+              name: "Investor Stats Q1"
+              max_uses: 10
+      responses:
+        '201':
+          description: Access code created successfully
+          headers:
+            Location:
+              description: URL of the created access code resource
+              schema:
+                type: string
+                format: uri
+                example: "https://api.layerv.ai/v1/access-codes/acd_k8xqp9h2sj9"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateAccessCodeResponse'
+              example:
+                data:
+                  access_code_id: "acd_k8xqp9h2sj9"
+                  code: "ac_k8xqp9h2sj9lx7r4abcdef"
+                  resource_id: "r_k8xqp9h2sj9"
+                  name: "Investor Stats Q1"
+                  status: "active"
+                  max_uses: 10
+                  use_count: 0
+                  created_at: "2026-03-14T12:00:00Z"
+                meta:
+                  request_id: "req_abc123"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    get:
+      tags:
+        - Access Codes
+      summary: List access codes
+      description: |
+        Lists access codes owned by the authenticated user, sorted by creation date (newest first).
+        Requires system-tier account.
+      operationId: listAccessCodes
+      security:
+        - bearerAuth: [qurl:read]
+      responses:
+        '200':
+          description: List of access codes
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessCodeListResponse'
+              example:
+                data:
+                  - access_code_id: "acd_k8xqp9h2sj9"
+                    resource_id: "r_k8xqp9h2sj9"
+                    name: "Investor Stats Q1"
+                    status: "active"
+                    max_uses: 10
+                    use_count: 3
+                    created_at: "2026-03-14T12:00:00Z"
+                meta:
+                  request_id: "req_abc123"
+                  page_size: 1
+                  has_more: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/access-codes/{id}:
+    delete:
+      tags:
+        - Access Codes
+      summary: Revoke an access code
+      description: |
+        Revokes an access code, preventing further redemptions.
+        Requires system-tier account. The code must be owned by the authenticated user.
+      operationId: revokeAccessCode
+      security:
+        - bearerAuth: [qurl:write]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: "Access code ID (format: acd_ + 11 chars)"
+          schema:
+            type: string
+            pattern: '^acd_[a-z0-9_-]{11}$'
+      responses:
+        '204':
+          description: Access code revoked successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: oauth2
+      description: |
+        OAuth 2.1 compliant authentication via Auth0.
+
+        Uses Authorization Code flow with PKCE (RFC 7636) as required by OAuth 2.1.
+        Tokens must be passed via Authorization header only (RFC 6750 Section 2.1).
+        Query parameter and form body token transmission are explicitly rejected.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.layerv.ai/authorize
+          tokenUrl: https://auth.layerv.ai/oauth/token
+          scopes:
+            qurl:read: Read access to QURLs and quota
+            qurl:write: Create, update, and delete QURLs
+            qurl:resolve: Resolve access tokens and trigger firewall access
+
+  parameters:
+    QurlId:
+      name: id
+      in: path
+      required: true
+      description: |
+        Resource ID (r_ prefix) or QURL display ID (q_ prefix). Both are accepted.
+        The r_ ID identifies the protected URL; the q_ ID identifies a specific access token.
+        If a q_ ID is passed, the API resolves it to its parent resource automatically.
+      schema:
+        type: string
+        pattern: '^(r_[a-z0-9_-]{11}|q_[0-9a-f]{11})$'
+        example: "r_k8xqp9h2sj9"
+
+    WebhookId:
+      name: id
+      in: path
+      required: true
+      description: Webhook ID
+      schema:
+        type: string
+        pattern: '^wh_[A-Za-z0-9_-]{16}$'
+        example: "wh_abc123def456ghij"
+
+    DomainName:
+      name: domain
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Custom domain name
+
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: |
+        Unique key to ensure idempotent request processing.
+        If provided, duplicate requests with the same key return the cached response.
+        Maximum length: 256 characters.
+      schema:
+        type: string
+        maxLength: 256
+        example: "req_abc123_create_dashboard"
+
+  schemas:
+    CreateQurlRequest:
+      type: object
+      required:
+        - target_url
+      properties:
+        target_url:
+          type: string
+          format: uri
+          maxLength: 2048
+          description: The URL to protect with QURL (max 2048 characters)
+          example: "https://internal.example.com/dashboard"
+        expires_in:
+          type: string
+          description: |
+            Duration until expiration. Supports: hours (24h), days (7d), weeks (1w).
+            Minimum: 1 minute. Maximum varies by plan: free=3 days, growth/enterprise=30 days. Default: 24h.
+          example: "7d"
+        one_time_use:
+          type: boolean
+          description: Whether this QURL expires after a single use
+          default: false
+        max_sessions:
+          type: integer
+          minimum: 0
+          maximum: 1000
+          description: |
+            Maximum concurrent sessions allowed.
+            0 = unlimited (default), 1-1000 = hard limit.
+        session_duration:
+          type: string
+          description: |
+            How long access lasts after someone clicks this QURL.
+            Controls the session/cookie lifetime, separate from the QURL link expiration (expires_in).
+            Supports: minutes (5m), hours (1h), days (1d). Minimum: 5 minutes. Maximum: 24 hours.
+            Default: server default (typically 1 hour).
+          example: "1h"
+        access_policy:
+          $ref: '#/components/schemas/AccessPolicy'
+        label:
+          type: string
+          description: Human-readable label identifying who this QURL is for
+          maxLength: 500
+          example: "Alice from Acme"
+        custom_domain:
+          type: string
+          maxLength: 253
+          description: |
+            Optional custom domain to assign to the auto-created resource.
+            The domain must be registered, active, and owned by the caller.
+            Only allowed when the target URL creates a new resource — rejected
+            if a resource already exists for this target URL.
+          example: "app.example.com"
+
+    CreateResourceRequest:
+      type: object
+      required:
+        - target_url
+      properties:
+        target_url:
+          type: string
+          format: uri
+          maxLength: 2048
+          description: The URL to protect
+        description:
+          type: string
+          maxLength: 500
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 50
+          maxItems: 10
+        custom_domain:
+          type: string
+
+    UpdateResourceRequest:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 500
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 50
+          maxItems: 10
+        custom_domain:
+          type: string
+        preserve_host:
+          type: boolean
+          description: |
+            Whether to preserve the original Host header when proxying to the origin
+            via a custom domain. When true, the custom domain is sent as the Host header.
+            When false (default), the target server's hostname is used.
+            Only meaningful when custom_domain is set.
+
+    ResourceData:
+      type: object
+      properties:
+        resource_id:
+          type: string
+          pattern: '^r_[a-z0-9_-]{11}$'
+        target_url:
+          type: string
+        status:
+          type: string
+          enum: [active, revoked]
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        custom_domain:
+          type: string
+          nullable: true
+        preserve_host:
+          type: boolean
+          description: Whether to preserve the original Host header when proxying via custom domain
+          default: false
+        qurl_count:
+          type: integer
+          description: Number of active QURLs for this resource
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+
+    ResourceDetailData:
+      type: object
+      properties:
+        resource:
+          $ref: '#/components/schemas/ResourceData'
+        qurls:
+          type: array
+          items:
+            $ref: '#/components/schemas/QurlSummary'
+
+    QurlSummary:
+      type: object
+      properties:
+        qurl_id:
+          type: string
+        label:
+          type: string
+        status:
+          type: string
+          enum: [active, consumed, expired, revoked]
+        one_time_use:
+          type: boolean
+        max_sessions:
+          type: integer
+        session_duration:
+          type: integer
+          description: Session lifetime in seconds (0 = server default)
+        use_count:
+          type: integer
+        qurl_site:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+        access_policy:
+          $ref: '#/components/schemas/AccessPolicy'
+
+    UpdateQurlTokenRequest:
+      type: object
+      minProperties: 1
+      description: |
+        Update a specific QURL token. Can extend expiration, update label,
+        access policy, or max_sessions. At least one field must be provided.
+        For expiry: provide exactly one of extend_by (relative) or expires_at (absolute).
+      properties:
+        extend_by:
+          type: string
+          description: |
+            Duration to extend by (e.g., "24h", "7d").
+            Minimum: 1 minute. Maximum: 30 days.
+            Mutually exclusive with expires_at.
+          example: "7d"
+        expires_at:
+          type: string
+          format: date-time
+          description: |
+            Absolute expiration timestamp (RFC 3339).
+            Must be in the future and within 30 days.
+            Mutually exclusive with extend_by.
+        label:
+          type: string
+          maxLength: 500
+          description: Human-readable label for this QURL.
+        access_policy:
+          $ref: '#/components/schemas/AccessPolicy'
+        max_sessions:
+          type: integer
+          minimum: 0
+          maximum: 1000
+          description: Maximum concurrent sessions (0 = unlimited).
+        session_duration:
+          type: string
+          description: |
+            How long access lasts after clicking. Minimum: 5 minutes. Maximum: 24 hours.
+          example: "1h"
+
+    QurlSummaryResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/QurlSummary'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    SessionData:
+      type: object
+      properties:
+        session_id:
+          type: string
+          description: Unique session identifier
+        qurl_id:
+          type: string
+          description: QURL display ID (q_ prefix) that created this session
+        src_ip:
+          type: string
+          description: Client IP that created the session
+        user_agent:
+          type: string
+          description: Client user agent
+        created_at:
+          type: string
+          format: date-time
+        last_seen_at:
+          type: string
+          format: date-time
+
+    SessionListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/SessionData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    SessionTerminateResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            terminated:
+              type: integer
+              description: Number of sessions terminated
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    ResourceResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/ResourceData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    ResourceDetailResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/ResourceDetailData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    ResourceListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceData'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+
+    UpdateQurlRequest:
+      type: object
+      description: |
+        Update a QURL resource. Can extend expiration (via extend_by or expires_at)
+        and/or update tags and description. At least one field must be provided.
+      properties:
+        extend_by:
+          type: string
+          description: |
+            Duration to extend by (e.g., "24h", "7d", "1w").
+            Minimum: 1 minute. Maximum: 30 days.
+            Mutually exclusive with expires_at.
+          example: "7d"
+        expires_at:
+          type: string
+          format: date-time
+          description: |
+            Absolute expiration time. Mutually exclusive with extend_by.
+            Must be in the future and within 30 days from now.
+        tags:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 50
+            pattern: '^[a-zA-Z0-9][a-zA-Z0-9 _-]*$'
+          maxItems: 10
+          uniqueItems: true
+          description: |
+            Replace all tags on this resource. Tags are lowercased and trimmed
+            server-side. Duplicates are silently removed. Pass an empty array
+            to clear all tags.
+        description:
+          type: string
+          maxLength: 500
+          description: Replace the resource description. Pass an empty string to clear.
+
+    MintLinkRequest:
+      type: object
+      description: |
+        Optionally provide expires_in (relative) or expires_at (absolute) — not both.
+        If neither is specified, defaults to 24 hours from now.
+      properties:
+        expires_in:
+          type: string
+          description: |
+            Duration until expiration. Supports: minutes (5m), hours (24h), days (7d), weeks (1w).
+            Minimum: 1 minute. Maximum: 30 days.
+          example: "5m"
+        expires_at:
+          type: string
+          format: date-time
+          description: |
+            Absolute expiration timestamp. Must be in the future and within 30 days from now.
+            Mutually exclusive with expires_in.
+        label:
+          type: string
+          description: Human-readable label identifying who this QURL is for
+          maxLength: 500
+          example: "Alice from Acme"
+        one_time_use:
+          type: boolean
+          description: Whether this QURL can only be used once
+          default: false
+        max_sessions:
+          type: integer
+          description: Maximum concurrent sessions (0 = unlimited)
+          minimum: 0
+          maximum: 1000
+          default: 0
+        session_duration:
+          type: string
+          description: |
+            How long access lasts after clicking. Minimum: 5 minutes. Maximum: 24 hours.
+          example: "1h"
+        access_policy:
+          $ref: '#/components/schemas/AccessPolicy'
+
+    AccessPolicy:
+      type: object
+      description: Access control policy for the QURL
+      x-go-type: domain.AccessPolicy
+      x-go-type-import:
+        path: github.com/layervai/qurl-service/internal/domain
+      properties:
+        ip_allowlist:
+          type: array
+          maxItems: 100
+          items:
+            type: string
+          description: List of allowed IP addresses or CIDR ranges (max 100 entries)
+          example: ["192.168.1.0/24", "10.0.0.1"]
+        ip_denylist:
+          type: array
+          maxItems: 100
+          items:
+            type: string
+          description: List of denied IP addresses or CIDR ranges (max 100 entries)
+        geo_allowlist:
+          type: array
+          maxItems: 50
+          items:
+            type: string
+            pattern: '^[A-Z]{2}$'
+          description: List of allowed country codes (ISO 3166-1 alpha-2, max 50 entries)
+          example: ["US", "CA", "GB"]
+        geo_denylist:
+          type: array
+          maxItems: 50
+          items:
+            type: string
+            pattern: '^[A-Z]{2}$'
+          description: List of denied country codes (ISO 3166-1 alpha-2, max 50 entries)
+          example: ["CN", "RU"]
+        user_agent_allow_regex:
+          type: string
+          maxLength: 256
+          description: Regular expression to allow matching user agents (max 256 characters)
+          example: "^Mozilla.*"
+        user_agent_deny_regex:
+          type: string
+          maxLength: 256
+          description: Regular expression to deny matching user agents (max 256 characters)
+          example: ".*bot.*"
+        ai_agent_policy:
+          $ref: '#/components/schemas/AIAgentPolicy'
+
+    AIAgentCategory:
+      type: string
+      description: A well-known AI agent category identifier
+      enum:
+        - chatgpt
+        - gptbot
+        - claude
+        - gemini
+        - perplexity
+        - cohere
+        - meta
+        - bytedance
+        - amazon
+        - apple
+        - commoncrawl
+        - mistral
+        - generic_ai
+
+    AIAgentPolicy:
+      type: object
+      x-go-type: domain.AIAgentPolicy
+      x-go-type-import:
+        path: github.com/layervai/qurl-service/internal/domain
+      description: |
+        Structured policy for controlling AI agent access.
+        Users select well-known categories by name instead of crafting regex patterns.
+        The server maintains the user-agent patterns for each category.
+
+        **Important:** This blocks agents that self-identify via their User-Agent header.
+        It does not prevent agents that spoof or omit their identity.
+
+        Evaluation order: AI agent policy is evaluated after IP/Geo rules but before
+        generic user_agent_deny_regex / user_agent_allow_regex. A bot allowed by this
+        policy can still be blocked by user_agent_deny_regex. A bot blocked here cannot
+        be rescued by user_agent_allow_regex.
+
+        Common examples:
+
+        Block all AI agents:
+          { "block_all": true }
+
+        Block specific crawlers (e.g., GPTBot and Common Crawl) while allowing others:
+          { "deny_categories": ["gptbot", "commoncrawl"] }
+
+        Allow only Claude and Perplexity, block all other AI agents:
+          { "allow_categories": ["claude", "perplexity"] }
+
+        Block ByteDance and Meta crawlers but allow ChatGPT and Claude:
+          { "deny_categories": ["bytedance", "meta"], "allow_categories": ["chatgpt", "claude"] }
+
+        Note: deny always takes precedence over allow. If an agent appears in both lists, it is blocked.
+      properties:
+        block_all:
+          type: boolean
+          description: Block all recognized AI agents regardless of category lists
+          default: false
+        deny_categories:
+          type: array
+          maxItems: 20
+          items:
+            $ref: '#/components/schemas/AIAgentCategory'
+          description: |
+            AI agent categories to block. Ignored if block_all is true.
+            Deny takes precedence over allow.
+          example: ["gptbot", "commoncrawl", "bytedance"]
+        allow_categories:
+          type: array
+          maxItems: 20
+          items:
+            $ref: '#/components/schemas/AIAgentCategory'
+          description: |
+            AI agent categories to permit. When set, all other AI agents are blocked.
+            Deny takes precedence. Ignored if block_all is true.
+          example: ["claude", "chatgpt", "perplexity"]
+
+    QurlData:
+      type: object
+      description: |
+        Resource container for a protected URL. The `qurls` array (present on
+        single-get responses) contains per-QURL details including access policy
+        and session limits. On list responses, only `qurl_count` is populated.
+      properties:
+        resource_id:
+          type: string
+          pattern: '^r_[a-z0-9_-]{11}$'
+          readOnly: true
+          description: Unique resource identifier (generated by server)
+        target_url:
+          type: string
+          format: uri
+          description: The protected backend URL
+        status:
+          type: string
+          enum: [active, revoked]
+          readOnly: true
+          description: |
+            Current lifecycle status. Computed at response time — resources past
+            their expires_at are reported as "expired" even if not explicitly revoked.
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: When the QURL was created
+        expires_at:
+          type: string
+          format: date-time
+          description: When the QURL expires
+        description:
+          type: string
+          description: Human-readable description
+        tags:
+          type: array
+          items:
+            type: string
+            maxLength: 50
+          description: Tags for categorization and filtering
+        qurl_site:
+          type: string
+          format: uri
+          readOnly: true
+          description: The QURL site URL for accessing this resource
+        custom_domain:
+          type: string
+          nullable: true
+          readOnly: true
+          description: Custom domain associated with this QURL
+        qurl_count:
+          type: integer
+          readOnly: true
+          description: Number of active QURLs (access tokens) for this resource
+        qurls:
+          type: array
+          readOnly: true
+          description: Per-QURL details. Present on single-get, omitted on list (too expensive).
+          items:
+            $ref: '#/components/schemas/QurlSummary'
+
+    CreateQurlData:
+      type: object
+      description: Response data for QURL creation
+      properties:
+        qurl_id:
+          type: string
+          pattern: '^q_[a-f0-9]{11}$'
+          readOnly: true
+          description: |
+            Unique QURL identifier (q_ + first 11 hex chars of token hash).
+            Used as NHP resource ID and qurl_site subdomain. Each QURL gets
+            its own firewall rules keyed by this ID.
+          example: "q_3a7f2c8e91b"
+        resource_id:
+          type: string
+          pattern: '^r_[a-z0-9_-]{11}$'
+          readOnly: true
+          description: Parent resource ID (auto-created grouping by target URL)
+        qurl_link:
+          type: string
+          format: uri
+          readOnly: true
+          description: Ephemeral access link (shown once, cannot be recovered)
+        qurl_site:
+          type: string
+          format: uri
+          readOnly: true
+          description: Per-QURL site URL (https://{qurl_id}.qurl.site)
+        expires_at:
+          type: string
+          format: date-time
+          readOnly: true
+        label:
+          type: string
+          readOnly: true
+          description: Human-readable label for this QURL
+
+    QurlResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/QurlData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    CreateQurlResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/CreateQurlData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    ResolveQurlRequest:
+      type: object
+      required:
+        - access_token
+      properties:
+        access_token:
+          type: string
+          description: QURL access token (e.g., "at_k8xqp9h2sj9lx7r4abcdef")
+          pattern: '^at_[a-z0-9_-]{22}$'
+          example: "at_k8xqp9h2sj9lx7r4abcdef"
+
+    ResolveQurlResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/ResolveQurlData'
+        error:
+          $ref: '#/components/schemas/Error'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    ResolveQurlData:
+      type: object
+      properties:
+        target_url:
+          type: string
+          format: uri
+          description: The URL that is now accessible from the caller's IP
+          example: "https://api.example.com/data"
+        resource_id:
+          type: string
+          description: QURL resource identifier
+          example: "r_k8xqp9h2sj9"
+        access_grant:
+          $ref: '#/components/schemas/AccessGrant'
+
+    AccessGrant:
+      type: object
+      description: Details of the firewall access that was granted
+      properties:
+        expires_in:
+          type: integer
+          description: Seconds until firewall access expires
+          example: 305
+        granted_at:
+          type: string
+          format: date-time
+          description: When the access was granted
+          example: "2026-03-09T15:30:00Z"
+        src_ip:
+          type: string
+          description: The IP address that was granted access
+          example: "203.0.113.42"
+
+    QurlListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/QurlData'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+
+    MintLinkData:
+      type: object
+      properties:
+        qurl_link:
+          type: string
+          format: uri
+          readOnly: true
+          description: Single-use access link
+        expires_at:
+          type: string
+          format: date-time
+          readOnly: true
+
+    MintLinkResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/MintLinkData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    BatchCreateRequest:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          minItems: 1
+          maxItems: 100
+          description: Array of QURL creation requests (1-100 items)
+          items:
+            $ref: '#/components/schemas/CreateQurlRequest'
+
+    BatchCreateResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            succeeded:
+              type: integer
+              readOnly: true
+              description: Number of successfully created QURLs
+            failed:
+              type: integer
+              readOnly: true
+              description: Number of failed creations
+            results:
+              type: array
+              items:
+                $ref: '#/components/schemas/BatchItemResult'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    BatchItemResult:
+      type: object
+      properties:
+        index:
+          type: integer
+          readOnly: true
+          description: Original index in the request array
+        success:
+          type: boolean
+          readOnly: true
+        resource_id:
+          type: string
+          readOnly: true
+          description: Created resource ID (if success)
+        qurl_link:
+          type: string
+          format: uri
+          readOnly: true
+          description: Access link (if success)
+        qurl_site:
+          type: string
+          format: uri
+          readOnly: true
+          description: QURL site URL (if success)
+        expires_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: Expiration time (if success)
+        error:
+          type: object
+          readOnly: true
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+          description: Error details (if failed)
+
+    QuotaData:
+      type: object
+      properties:
+        plan:
+          type: string
+          enum: [free, growth, enterprise]
+          readOnly: true
+        period_start:
+          type: string
+          format: date-time
+          readOnly: true
+        period_end:
+          type: string
+          format: date-time
+          readOnly: true
+        rate_limits:
+          type: object
+          readOnly: true
+          properties:
+            create_per_minute:
+              type: integer
+            create_per_hour:
+              type: integer
+            list_per_minute:
+              type: integer
+            resolve_per_minute:
+              type: integer
+              description: Rate limit for internal token resolution (used by access infrastructure)
+            max_active_qurls:
+              type: integer
+              description: Maximum active QURLs allowed (-1 = unlimited)
+            max_tokens_per_qurl:
+              type: integer
+              description: Maximum tokens per QURL (-1 = unlimited)
+            max_expiry_seconds:
+              type: integer
+              description: Maximum expiry duration in seconds (free=259200/3d, growth=2592000/30d, enterprise=2592000/30d)
+        usage:
+          type: object
+          readOnly: true
+          properties:
+            qurls_created:
+              type: integer
+              description: Total QURLs created this period
+            active_qurls:
+              type: integer
+              description: Currently active QURLs
+            active_qurls_percent:
+              type: number
+              format: float
+              minimum: 0
+              maximum: 100
+              nullable: true
+              description: Percentage of max_active_qurls used (0-100, null if unlimited)
+            total_accesses:
+              type: integer
+              description: Total access attempts this period
+
+    QuotaResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/QuotaData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    # Usage schemas
+    UsageCostEstimate:
+      type: object
+      required:
+        - currency
+        - amount_cents
+        - description
+      properties:
+        currency:
+          type: string
+          description: Currency code (e.g. "usd")
+          example: "usd"
+        amount_cents:
+          type: integer
+          description: Cost in cents
+          example: 1500
+        description:
+          type: string
+          description: Human-readable breakdown
+          example: "150 QURLs x $0.10/QURL"
+
+    UsageCurrentPeriodData:
+      type: object
+      required:
+        - tier
+        - period_start
+        - period_end
+        - qurls_created
+        - active_qurls
+      properties:
+        tier:
+          type: string
+          enum: [free, growth, enterprise]
+          description: Current billing tier
+        period_start:
+          type: string
+          format: date-time
+          description: Start of the current billing period (UTC)
+        period_end:
+          type: string
+          format: date-time
+          description: End of the current billing period (UTC)
+        qurls_created:
+          type: integer
+          description: Number of QURLs created in this period
+        active_qurls:
+          type: integer
+          description: Number of currently active (non-expired, non-revoked) QURLs
+        cost_estimate:
+          $ref: '#/components/schemas/UsageCostEstimate'
+
+    UsageCurrentPeriodResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/UsageCurrentPeriodData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    UsageDailyEntry:
+      type: object
+      required:
+        - date
+        - qurls_created
+      properties:
+        date:
+          type: string
+          format: date
+          description: Calendar date (YYYY-MM-DD)
+        qurls_created:
+          type: integer
+          description: QURLs created on this date
+
+    UsageDailyData:
+      type: object
+      required:
+        - tier
+        - period_start
+        - period_end
+        - daily
+      properties:
+        tier:
+          type: string
+          enum: [free, growth, enterprise]
+          description: Current billing tier
+        period_start:
+          type: string
+          format: date-time
+          description: Start of the current billing period (UTC)
+        period_end:
+          type: string
+          format: date-time
+          description: End of the current billing period (UTC)
+        daily:
+          type: array
+          items:
+            $ref: '#/components/schemas/UsageDailyEntry'
+          description: One entry per day from period_start to today
+
+    UsageDailyResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/UsageDailyData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    # API Key schemas
+    CreateApiKeyRequest:
+      type: object
+      required:
+        - name
+        - scopes
+      properties:
+        name:
+          type: string
+          maxLength: 100
+          description: Human-readable name for the API key
+        scopes:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            enum: [qurl:read, qurl:write, qurl:resolve]
+          description: Permissions granted to this API key
+
+    UpdateApiKeyRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 100
+          description: Updated name for the API key
+        scopes:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            enum: [qurl:read, qurl:write, qurl:resolve]
+          description: |
+            Updated permissions for the API key.
+            Omit this field to leave scopes unchanged.
+            When provided, replaces all existing scopes (not a merge).
+
+    ApiKeyData:
+      type: object
+      properties:
+        key_id:
+          type: string
+          pattern: '^key_[A-Za-z0-9]{12}$'
+          readOnly: true
+        key_prefix:
+          type: string
+          readOnly: true
+          description: >-
+            First 12 characters of the key for identification.
+            Includes the environment prefix (e.g., "lv_live_a3x9").
+        name:
+          type: string
+        scopes:
+          type: array
+          items:
+            type: string
+          description: >-
+            Permissions granted to this API key.
+            Returned in alphabetical order for deterministic responses.
+        status:
+          type: string
+          enum: [active, revoked]
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: >-
+            Timestamp of the last update to name or scopes.
+            Omitted if the key has never been updated.
+        last_used_at:
+          type: string
+          format: date-time
+          readOnly: true
+
+    CreateApiKeyData:
+      allOf:
+        - $ref: '#/components/schemas/ApiKeyData'
+        - type: object
+          properties:
+            api_key:
+              type: string
+              readOnly: true
+              description: |
+                The plaintext API key. This is returned only once at creation time.
+                Store it securely - it cannot be retrieved again.
+
+    CreateApiKeyResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/CreateApiKeyData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    ApiKeyResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/ApiKeyData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    ApiKeyListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiKeyData'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+
+    # --- Access Codes ---
+
+    RedeemAccessCodeRequest:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          description: The plaintext access code to redeem
+          pattern: '^ac_[a-z0-9_-]{22}$'
+          example: "ac_k8xqp9h2sj9lx7r4abcdef"
+        honeypot:
+          type: string
+          description: Honeypot field for bot detection (must be empty)
+          default: ""
+        elapsed_ms:
+          type: integer
+          description: Milliseconds elapsed since page load (for bot detection)
+          example: 5200
+
+    RedeemAccessCodeData:
+      type: object
+      properties:
+        redirect_url:
+          type: string
+          format: uri
+          readOnly: true
+          description: URL to redirect the user to for resource access
+          example: "https://qurl.link/#at_k8xqp9h2sj9lx7r4abcdef"
+
+    RedeemAccessCodeResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/RedeemAccessCodeData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    CreateAccessCodeRequest:
+      type: object
+      required:
+        - resource_id
+      properties:
+        resource_id:
+          type: string
+          description: ID of the QURL resource this code grants access to
+          pattern: '^r_[a-z0-9_-]{11}$'
+          example: "r_k8xqp9h2sj9"
+        name:
+          type: string
+          description: Human-readable label for the access code
+          maxLength: 100
+          example: "Investor Stats Q1"
+        max_uses:
+          type: integer
+          description: Maximum number of times this code can be redeemed (0 = unlimited)
+          minimum: 0
+          default: 0
+          example: 10
+        expires_at:
+          type: string
+          format: date-time
+          description: Optional expiration time for the access code
+
+    AccessCodeData:
+      type: object
+      properties:
+        access_code_id:
+          type: string
+          readOnly: true
+          description: Unique identifier for the access code
+          pattern: '^acd_[a-z0-9_-]{11}$'
+          example: "acd_k8xqp9h2sj9"
+        resource_id:
+          type: string
+          description: ID of the QURL resource this code grants access to
+          example: "r_k8xqp9h2sj9"
+        name:
+          type: string
+          description: Human-readable label
+          example: "Investor Stats Q1"
+        status:
+          type: string
+          enum: [active, revoked]
+          readOnly: true
+          description: Current status of the access code
+        max_uses:
+          type: integer
+          description: Maximum redemptions allowed (0 = unlimited)
+          example: 10
+        use_count:
+          type: integer
+          readOnly: true
+          description: Number of times this code has been redeemed
+          example: 3
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+          readOnly: true
+
+    CreateAccessCodeData:
+      allOf:
+        - $ref: '#/components/schemas/AccessCodeData'
+        - type: object
+          properties:
+            code:
+              type: string
+              readOnly: true
+              description: |
+                The plaintext access code. This is returned only once at creation time
+                and cannot be retrieved later (it is stored as a SHA-256 hash).
+              pattern: '^ac_[a-z0-9_-]{22}$'
+              example: "ac_k8xqp9h2sj9lx7r4abcdef"
+
+    CreateAccessCodeResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/CreateAccessCodeData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    AccessCodeListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccessCodeData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    # Webhook schemas
+    WebhookEventType:
+      type: string
+      enum:
+        - qurl.created
+        - qurl.expired
+        - qurl.revoked
+        - qurl.updated
+        - qurl.accessed
+        - qurl.access_denied
+        - qurl.token_exhausted
+        - quota.warning
+        - quota.exceeded
+        - token.minted
+        - token.expired
+        - domain.verified
+        - domain.failed
+        - domain.deleted
+      description: |
+        Webhook event types:
+        - **qurl.created** - A new QURL was created
+        - **qurl.expired** - A QURL has expired
+        - **qurl.revoked** - A QURL was manually revoked
+        - **qurl.updated** - A QURL was updated (expiration, tags, or description)
+        - **qurl.accessed** - A QURL was successfully accessed
+        - **qurl.access_denied** - Access to a QURL was denied by policy
+        - **qurl.token_exhausted** - A one-time-use token was fully consumed
+        - **quota.warning** - Approaching quota limit (80%)
+        - **quota.exceeded** - Quota limit reached, action blocked
+        - **token.minted** - A new access token was created
+        - **token.expired** - An access token has expired
+        - **domain.verified** - A custom domain was successfully verified
+        - **domain.failed** - Custom domain verification or cert provisioning failed
+        - **domain.deleted** - A custom domain was deleted
+
+    CreateWebhookRequest:
+      type: object
+      required:
+        - url
+        - events
+      properties:
+        url:
+          type: string
+          format: uri
+          maxLength: 2048
+          description: HTTPS endpoint URL to receive webhook events (max 2048 characters)
+          example: "https://example.com/webhooks/qurl"
+        events:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/WebhookEventType'
+          description: Event types to subscribe to
+        description:
+          type: string
+          maxLength: 500
+          description: Human-readable description
+
+    UpdateWebhookRequest:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          maxLength: 2048
+        events:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/WebhookEventType'
+        description:
+          type: string
+          maxLength: 500
+        status:
+          type: string
+          enum: [active, disabled]
+
+    WebhookData:
+      type: object
+      properties:
+        webhook_id:
+          type: string
+          pattern: '^wh_[A-Za-z0-9_-]{16}$'
+          readOnly: true
+        url:
+          type: string
+          format: uri
+          maxLength: 2048
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/WebhookEventType'
+        status:
+          type: string
+          enum: [active, disabled]
+          readOnly: true
+        description:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        failure_count:
+          type: integer
+          readOnly: true
+          description: Consecutive delivery failures
+        last_delivery_success:
+          type: boolean
+          readOnly: true
+        last_delivery_time:
+          type: integer
+          readOnly: true
+          description: Unix timestamp of last delivery attempt
+
+    WebhookDataWithSecret:
+      allOf:
+        - $ref: '#/components/schemas/WebhookData'
+        - type: object
+          properties:
+            secret:
+              type: string
+              readOnly: true
+              description: |
+                HMAC signing secret (only returned on create or regenerate).
+                Use this to verify the QURL-Signature header on incoming webhooks.
+              example: "whsec_K8xQp9H2sJ9Lx7R4AaBbCcDdEeFf..."
+
+    WebhookResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/WebhookData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    WebhookResponseWithSecret:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/WebhookDataWithSecret'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    WebhookListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/WebhookData'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+
+    WebhookDeliveryData:
+      type: object
+      properties:
+        delivery_id:
+          type: string
+          pattern: '^wd_[A-Za-z0-9_-]{16}$'
+          readOnly: true
+        webhook_id:
+          type: string
+          readOnly: true
+        event_type:
+          $ref: '#/components/schemas/WebhookEventType'
+        status:
+          type: string
+          enum: [pending, success, failed, retrying, abandoned]
+          readOnly: true
+        response_code:
+          type: integer
+          readOnly: true
+        response_body:
+          type: string
+          readOnly: true
+          description: Truncated response body (max 8KB)
+        error_message:
+          type: string
+          readOnly: true
+        duration_ms:
+          type: integer
+          readOnly: true
+        retry_count:
+          type: integer
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        completed_at:
+          type: string
+          format: date-time
+          readOnly: true
+
+    WebhookDeliveryListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/WebhookDeliveryData'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+
+    WebhookEventTypeInfo:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/WebhookEventType'
+        category:
+          type: string
+          enum: [resource, access, quota, token]
+        description:
+          type: string
+
+    WebhookEventTypesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/WebhookEventTypeInfo'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    WebhookPayload:
+      type: object
+      description: |
+        Webhook event payload sent to your endpoint.
+        Verify authenticity using the QURL-Signature header.
+      properties:
+        id:
+          type: string
+          description: Unique event ID
+        type:
+          $ref: '#/components/schemas/WebhookEventType'
+        owner_id:
+          type: string
+          description: Owner who triggered the event
+        timestamp:
+          type: string
+          format: date-time
+        api_version:
+          type: string
+          description: API version (e.g., "2024-01-01")
+        data:
+          type: object
+          additionalProperties: true
+          description: Event-specific data
+      example:
+        id: "evt_abc123def456"
+        type: "qurl.accessed"
+        owner_id: "auth0|user123"
+        timestamp: "2024-01-08T10:35:00Z"
+        api_version: "2024-01-01"
+        data:
+          resource_id: "r_k8xqp9h2sj9"
+          access_token_id: "at_xyz789"
+          src_ip: "192.168.1.100"
+          user_agent: "Mozilla/5.0..."
+
+    # Customer schemas
+    CustomerData:
+      type: object
+      required:
+        - tier
+        - spending_cap_cents
+        - current_period_usage
+        - frozen
+      properties:
+        tier:
+          type: string
+          enum: [free, growth, enterprise]
+          description: Customer's billing tier
+        spending_cap_cents:
+          type: integer
+          format: int64
+          description: Spending cap in cents (0 = no cap)
+        current_period_usage:
+          type: integer
+          format: int64
+          description: Usage count in current billing period
+        frozen:
+          type: boolean
+          description: Whether the account is frozen
+        frozen_reason:
+          type: string
+          nullable: true
+          description: Reason for account freeze
+          enum: [spending_cap, payment_failed, manual]
+
+    CustomerResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/CustomerData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    UpdateCustomerRequest:
+      type: object
+      required:
+        - spending_cap_cents
+      properties:
+        spending_cap_cents:
+          type: integer
+          format: int64
+          minimum: 0
+          maximum: 10000000
+          description: New spending cap in cents (0 = no cap)
+
+    # Billing schemas
+    CreateBillingCheckoutRequest:
+      type: object
+      required:
+        - plan
+      # Reject unknown fields at the middleware layer so client typos
+      # (`plans` vs `plan`, stray `coupon`, etc.) surface as a 400 on the
+      # typo itself instead of as a confusing "missing required property"
+      # on `plan`. No forward-compat risk — server-side additions to this
+      # schema land alongside their consumers.
+      additionalProperties: false
+      properties:
+        plan:
+          type: string
+          enum:
+            - growth
+          # x-enum-varnames pins the generated constant name so the handler's
+          # switch stays robust against any future oapi-codegen single-value
+          # enum naming change. Current versions prefix by type anyway; this
+          # is cheap future-proofing, not a bug workaround.
+          x-enum-varnames: [CreateBillingCheckoutRequestPlanGrowth]
+          description: |
+            Paid plan to check out into. Only purchasable plans are
+            permitted (currently: `growth`). Anything else is rejected
+            at the OpenAPI middleware layer as an invalid enum value
+            before the handler runs.
+
+    CheckoutSessionData:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Stripe Checkout URL to redirect user to
+
+    CheckoutSessionResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/CheckoutSessionData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    PortalSessionData:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Stripe Billing Portal URL to redirect user to
+
+    PortalSessionResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/PortalSessionData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    InvoiceData:
+      type: object
+      required:
+        - id
+        - amount_cents
+        - status
+        - created_at
+      properties:
+        id:
+          type: string
+          description: Stripe invoice ID
+        amount_cents:
+          type: integer
+          format: int64
+          description: Invoice amount in cents
+        status:
+          type: string
+          enum: [paid, open, void, draft]
+          description: Invoice status
+        created_at:
+          type: string
+          format: date-time
+          description: When the invoice was created
+        pdf_url:
+          type: string
+          format: uri
+          nullable: true
+          description: URL to download the invoice PDF
+
+    InvoiceListData:
+      type: object
+      required:
+        - invoices
+      properties:
+        invoices:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceData'
+
+    InvoiceListResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/InvoiceListData'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+
+    # Custom Domain schemas
+    RegisterDomainRequest:
+      type: object
+      required:
+        - domain
+      properties:
+        domain:
+          type: string
+          description: The custom domain name to register
+          example: "secure.example.com"
+
+    DomainData:
+      type: object
+      properties:
+        domain:
+          type: string
+          readOnly: true
+          description: The custom domain name
+        status:
+          type: string
+          enum: [pending_verification, verified, provisioning_tls, active, failed]
+          readOnly: true
+          description: Current domain status
+        verification_token:
+          type: string
+          readOnly: true
+          description: TXT record value for DNS verification
+        token_expires_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+          description: |
+            When the verification token expires. Omitted for domains created
+            before token expiry was introduced (those tokens never expire).
+            After expiry, use the regenerate-token endpoint to get a new one.
+        acme_cname_target:
+          type: string
+          readOnly: true
+          description: CNAME target for ACME certificate provisioning
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        verified_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        activated_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        ready_for_qurls:
+          type: boolean
+          readOnly: true
+          description: Whether this domain is ready to be used with QURLs (status is verified, provisioning_tls, or active)
+        dns_records:
+          type: array
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/DnsRecord'
+          description: Required DNS records for domain setup
+
+    DnsRecord:
+      type: object
+      properties:
+        type:
+          type: string
+          description: DNS record type (TXT, CNAME)
+        name:
+          type: string
+          description: DNS record name
+        value:
+          type: string
+          description: DNS record value
+        verified:
+          type: boolean
+          description: Whether this record has been verified
+
+    DomainResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/DomainData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    DomainListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DomainData'
+        meta:
+          $ref: '#/components/schemas/ListMeta'
+
+    CheckDetail:
+      type: object
+      readOnly: true
+      required:
+        - verified
+      properties:
+        verified:
+          type: boolean
+        error:
+          type: string
+          description: Error message when the check fails (omitted when verified).
+        found:
+          type: string
+          description: The actual value found in DNS (omitted when nothing was found).
+
+    DomainVerifyData:
+      type: object
+      properties:
+        domain:
+          type: string
+          readOnly: true
+        status:
+          type: string
+          enum: [pending_verification, verified, provisioning_tls, active, failed]
+          readOnly: true
+        checks:
+          type: object
+          readOnly: true
+          properties:
+            txt:
+              $ref: '#/components/schemas/CheckDetail'
+            acme_cname:
+              $ref: '#/components/schemas/CheckDetail'
+            traffic_routing:
+              $ref: '#/components/schemas/CheckDetail'
+
+    DomainVerifyResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/DomainVerifyData'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    Meta:
+      type: object
+      required:
+        - request_id
+      properties:
+        request_id:
+          type: string
+          description: Unique request identifier for tracing
+
+    ListMeta:
+      type: object
+      required:
+        - request_id
+      properties:
+        request_id:
+          type: string
+        page_size:
+          type: integer
+          description: Number of items returned
+        has_more:
+          type: boolean
+          description: Whether more items exist
+        next_cursor:
+          type: string
+          description: Cursor for next page (empty if no more pages)
+
+    Error:
+      type: object
+      description: |
+        Error response following RFC 7807 Problem Details for HTTP APIs.
+        See: https://datatracker.ietf.org/doc/html/rfc7807
+      required:
+        - type
+        - title
+        - status
+        - code
+      properties:
+        type:
+          type: string
+          format: uri
+          description: |
+            URI reference that identifies the problem type (RFC 7807).
+            When dereferenced, it should provide human-readable documentation.
+          example: "https://api.qurl.link/problems/invalid_request"
+        title:
+          type: string
+          description: |
+            Short, human-readable summary of the problem type (RFC 7807).
+            This should not change from occurrence to occurrence.
+          example: "Invalid Request"
+        status:
+          type: integer
+          description: HTTP status code for this occurrence (RFC 7807).
+          example: 400
+        detail:
+          type: string
+          description: |
+            Human-readable explanation specific to this occurrence (RFC 7807).
+          example: "The target_url field must be a valid HTTPS URL"
+        instance:
+          type: string
+          format: uri-reference
+          description: |
+            URI reference that identifies the specific occurrence (RFC 7807).
+            Typically the request path.
+          example: "/v1/qurls"
+        code:
+          type: string
+          description: |
+            Machine-readable error code (extension field for backward compatibility).
+            Maps to the problem type slug.
+          example: "invalid_request"
+
+    ValidationError:
+      allOf:
+        - $ref: '#/components/schemas/Error'
+        - type: object
+          properties:
+            invalid_fields:
+              type: object
+              additionalProperties:
+                type: string
+              description: Map of field names to validation error messages
+              example:
+                target_url: "must be a valid HTTPS URL"
+                description: "must not exceed 500 characters"
+
+    ErrorEnvelope:
+      type: object
+      properties:
+        error:
+          $ref: '#/components/schemas/Error'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+    ValidationErrorEnvelope:
+      type: object
+      properties:
+        error:
+          $ref: '#/components/schemas/ValidationError'
+        meta:
+          $ref: '#/components/schemas/Meta'
+
+  responses:
+    BadRequest:
+      description: Invalid request parameters
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidationErrorEnvelope'
+          examples:
+            invalidLimit:
+              summary: Invalid limit parameter
+              value:
+                error:
+                  type: "https://api.qurl.link/problems/invalid_request"
+                  title: "Invalid Request"
+                  status: 400
+                  detail: "limit must be an integer between 1 and 100"
+                  instance: "/v1/qurls"
+                  code: "invalid_request"
+                meta:
+                  request_id: "abc123def456"
+            validationError:
+              summary: Multiple field validation errors
+              value:
+                error:
+                  type: "https://api.qurl.link/problems/validation_error"
+                  title: "Validation Error"
+                  status: 400
+                  detail: "One or more fields are invalid"
+                  instance: "/v1/qurls"
+                  code: "validation_error"
+                  invalid_fields:
+                    target_url: "must be a valid HTTPS URL"
+                    expires_in: "must be between 1m and 30d"
+                meta:
+                  request_id: "abc123def456"
+
+    Unauthorized:
+      description: Missing or invalid authentication
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            error:
+              type: "https://api.qurl.link/problems/invalid_token"
+              title: "Invalid Token"
+              status: 401
+              detail: "Token validation failed"
+              instance: "/v1/qurls"
+              code: "invalid_token"
+            meta:
+              request_id: "abc123def456"
+
+    Forbidden:
+      description: Insufficient permissions or quota exceeded
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          examples:
+            insufficientScope:
+              summary: Missing required scopes
+              value:
+                error:
+                  type: "https://api.qurl.link/problems/insufficient_scope"
+                  title: "Insufficient Scope"
+                  status: 403
+                  detail: "Missing required permissions: qurl:write"
+                  instance: "/v1/qurls"
+                  code: "insufficient_scope"
+                meta:
+                  request_id: "abc123def456"
+            quotaExceeded:
+              summary: Quota limit reached
+              value:
+                error:
+                  type: "https://api.qurl.link/problems/quota_exceeded"
+                  title: "Quota Exceeded"
+                  status: 403
+                  detail: "Active QURL limit reached (10/10)"
+                  instance: "/v1/qurls"
+                  code: "quota_exceeded"
+                meta:
+                  request_id: "abc123def456"
+
+    NotFound:
+      description: Resource not found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            error:
+              type: "https://api.qurl.link/problems/not_found"
+              title: "Resource Not Found"
+              status: 404
+              detail: "QURL not found"
+              instance: "/v1/qurls/01ABC123"
+              code: "not_found"
+            meta:
+              request_id: "abc123def456"
+
+    Gone:
+      description: Resource is no longer available (consumed, expired, or revoked)
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          examples:
+            tokenConsumed:
+              summary: Access token already used
+              value:
+                error:
+                  type: "https://api.qurl.link/problems/token_consumed"
+                  title: "Token Consumed"
+                  status: 410
+                  detail: "Access token has already been used"
+                  instance: "/v1/resolve"
+                  code: "token_consumed"
+                meta:
+                  request_id: "abc123def456"
+            tokenExpired:
+              summary: Access token has expired
+              value:
+                error:
+                  type: "https://api.qurl.link/problems/token_expired"
+                  title: "Token Expired"
+                  status: 410
+                  detail: "Access token has expired"
+                  instance: "/v1/resolve"
+                  code: "token_expired"
+                meta:
+                  request_id: "abc123def456"
+
+    BadGateway:
+      description: Upstream NHP knock failed
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            error:
+              type: "https://api.qurl.link/problems/knock_failed"
+              title: "Knock Failed"
+              status: 502
+              detail: "Failed to open firewall access. The token may have been consumed."
+              instance: "/v1/resolve"
+              code: "knock_failed"
+            meta:
+              request_id: "abc123def456"
+
+    RateLimitExceeded:
+      description: Rate limit exceeded
+      headers:
+        Retry-After:
+          description: Seconds to wait before retrying
+          schema:
+            type: integer
+        RateLimit-Limit:
+          description: Maximum requests allowed
+          schema:
+            type: integer
+        RateLimit-Remaining:
+          description: Requests remaining in window
+          schema:
+            type: integer
+        RateLimit-Reset:
+          description: Unix timestamp when limit resets
+          schema:
+            type: integer
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            error:
+              type: "https://api.qurl.link/problems/rate_limit_exceeded"
+              title: "Rate Limit Exceeded"
+              status: 429
+              detail: "Too many requests. Please try again later."
+              instance: "/v1/qurls"
+              code: "rate_limit_exceeded"
+            meta:
+              request_id: "abc123def456"
+
+    ServiceUnavailable:
+      description: Upstream service temporarily unavailable (e.g. Stripe rate limit)
+      headers:
+        Retry-After:
+          description: Seconds to wait before retrying
+          schema:
+            type: integer
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            error:
+              type: "https://api.qurl.link/problems/service_unavailable"
+              title: "Service Unavailable"
+              status: 503
+              detail: "Billing service temporarily unavailable, please retry"
+              instance: "/v1/billing/checkout"
+              code: "rate_limited"
+            meta:
+              request_id: "abc123def456"
+
+    InternalServerError:
+      description: Internal server error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            error:
+              type: "https://api.qurl.link/problems/internal_error"
+              title: "Internal Server Error"
+              status: 500
+              detail: "An unexpected error occurred. Please try again later."
+              instance: "/v1/quota"
+              code: "internal_error"
+            meta:
+              request_id: "abc123def456"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "eslint": "^10.2.1",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.4",
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=18"
@@ -2445,6 +2446,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "eslint": "^10.2.1",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "yaml": "^2.8.3"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/update-openapi-snapshot.sh
+++ b/scripts/update-openapi-snapshot.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Regenerate contract/openapi.snapshot.yaml from qurl-service.
+#
+# Usage:
+#   scripts/update-openapi-snapshot.sh [ref]
+#
+# Default ref is `origin/main` in the local qurl-service checkout. Override
+# with a tag/commit (e.g. `v1.2.3` or a SHA) to pin a specific snapshot.
+#
+# The script expects qurl-service checked out at ../qurl-service (sibling
+# directory layout). If your layout differs, set QURL_SERVICE_DIR.
+
+set -euo pipefail
+
+QURL_SERVICE_DIR="${QURL_SERVICE_DIR:-$(cd "$(dirname "$0")/../.." && pwd)/qurl-service}"
+REF="${1:-origin/main}"
+OUT="$(cd "$(dirname "$0")/.." && pwd)/contract/openapi.snapshot.yaml"
+
+if [ ! -d "$QURL_SERVICE_DIR/.git" ]; then
+  echo "error: $QURL_SERVICE_DIR is not a git checkout of qurl-service" >&2
+  echo "       override with QURL_SERVICE_DIR=/path/to/qurl-service" >&2
+  exit 2
+fi
+
+# Resolve ref → commit SHA so the snapshot header is deterministic even if
+# the caller passed a branch name that moves later.
+SHA=$(git -C "$QURL_SERVICE_DIR" rev-parse "$REF^{commit}")
+SRC_FILE="api/openapi.yaml"
+
+# Fetch the file at the resolved SHA (doesn't require checkout). Piping
+# through cat keeps the script composable if someone redirects output.
+CONTENT=$(git -C "$QURL_SERVICE_DIR" show "${SHA}:${SRC_FILE}")
+
+{
+  echo "# Snapshot of qurl-service/api/openapi.yaml — canonical API contract."
+  echo "# This file is vendored (not auto-generated) so the contract test runs"
+  echo "# hermetically without network or cross-repo checkout."
+  echo "#"
+  echo "# Source: layervai/qurl-service@${SHA}"
+  echo "# Regenerate with: scripts/update-openapi-snapshot.sh"
+  echo "#"
+  printf '%s\n' "$CONTENT"
+} > "$OUT"
+
+echo "wrote $OUT (source: qurl-service@${SHA:0:12})"

--- a/scripts/update-openapi-snapshot.sh
+++ b/scripts/update-openapi-snapshot.sh
@@ -22,15 +22,25 @@ if [ ! -d "$QURL_SERVICE_DIR/.git" ]; then
   exit 2
 fi
 
+# Refresh remote refs so `origin/main` (the default) points at the current
+# upstream tip, not whatever was last fetched locally. Without this, a
+# stale checkout would silently pin the snapshot to an old SHA. Harmless
+# when the caller passes an explicit SHA or tag.
+git -C "$QURL_SERVICE_DIR" fetch --quiet origin
+
 # Resolve ref → commit SHA so the snapshot header is deterministic even if
 # the caller passed a branch name that moves later.
 SHA=$(git -C "$QURL_SERVICE_DIR" rev-parse "$REF^{commit}")
 SRC_FILE="api/openapi.yaml"
 
-# Fetch the file at the resolved SHA (doesn't require checkout). Piping
-# through cat keeps the script composable if someone redirects output.
-CONTENT=$(git -C "$QURL_SERVICE_DIR" show "${SHA}:${SRC_FILE}")
-
+# Write to a sibling tempfile and `mv` into place so a Ctrl-C mid-write
+# can't leave the committed snapshot truncated. `mv` on the same
+# filesystem is atomic; the trap cleans up the tempfile if the script
+# aborts before the rename. Streaming `git show` directly into the
+# heredoc (rather than capturing into a shell variable) avoids trailing-
+# newline truncation and ARG_MAX/memory edges on very large specs.
+TMP="${OUT}.tmp.$$"
+trap 'rm -f "$TMP"' EXIT
 {
   echo "# Snapshot of qurl-service/api/openapi.yaml — canonical API contract."
   echo "# This file is vendored (not auto-generated) so the contract test runs"
@@ -39,7 +49,8 @@ CONTENT=$(git -C "$QURL_SERVICE_DIR" show "${SHA}:${SRC_FILE}")
   echo "# Source: layervai/qurl-service@${SHA}"
   echo "# Regenerate with: scripts/update-openapi-snapshot.sh"
   echo "#"
-  printf '%s\n' "$CONTENT"
-} > "$OUT"
+  git -C "$QURL_SERVICE_DIR" show "${SHA}:${SRC_FILE}"
+} > "$TMP"
+mv "$TMP" "$OUT"
 
 echo "wrote $OUT (source: qurl-service@${SHA:0:12})"

--- a/scripts/update-openapi-snapshot.sh
+++ b/scripts/update-openapi-snapshot.sh
@@ -22,6 +22,18 @@ if [ ! -d "$QURL_SERVICE_DIR/.git" ]; then
   exit 2
 fi
 
+# Verify the remote actually points at qurl-service. Without this, someone
+# with an unrelated repo at ../qurl-service that happens to contain
+# api/openapi.yaml could silently snapshot from the wrong source — the
+# header SHA would be from their fork, not upstream.
+REMOTE_URL=$(git -C "$QURL_SERVICE_DIR" remote get-url origin 2>/dev/null || echo "")
+if ! printf '%s' "$REMOTE_URL" | grep -q -E '[:/]qurl-service(\.git)?$'; then
+  echo "error: $QURL_SERVICE_DIR origin remote does not look like qurl-service:" >&2
+  echo "       $REMOTE_URL" >&2
+  echo "       expected a URL ending in :qurl-service or /qurl-service(.git)" >&2
+  exit 2
+fi
+
 # Refresh remote refs so `origin/main` (the default) points at the current
 # upstream tip, not whatever was last fetched locally. Without this, a
 # stale checkout would silently pin the snapshot to an old SHA. Harmless

--- a/scripts/update-openapi-snapshot.sh
+++ b/scripts/update-openapi-snapshot.sh
@@ -33,13 +33,22 @@ git -C "$QURL_SERVICE_DIR" fetch --quiet origin
 SHA=$(git -C "$QURL_SERVICE_DIR" rev-parse "$REF^{commit}")
 SRC_FILE="api/openapi.yaml"
 
+# Preflight: confirm the spec file actually exists at that SHA. Without
+# this, a missing/renamed SRC_FILE surfaces as a bare `git show` error
+# mid-pipeline — clear-up-front message is friendlier to the operator.
+if ! git -C "$QURL_SERVICE_DIR" cat-file -e "${SHA}:${SRC_FILE}" 2>/dev/null; then
+  echo "error: ${SRC_FILE} not found at qurl-service@${SHA:0:12}" >&2
+  echo "       has the spec moved in qurl-service? update SRC_FILE in $0" >&2
+  exit 2
+fi
+
 # Write to a sibling tempfile and `mv` into place so a Ctrl-C mid-write
 # can't leave the committed snapshot truncated. `mv` on the same
 # filesystem is atomic; the trap cleans up the tempfile if the script
 # aborts before the rename. Streaming `git show` directly into the
 # heredoc (rather than capturing into a shell variable) avoids trailing-
 # newline truncation and ARG_MAX/memory edges on very large specs.
-TMP="${OUT}.tmp.$$"
+TMP=$(mktemp "${OUT}.tmp.XXXXXX")
 trap 'rm -f "$TMP"' EXIT
 {
   echo "# Snapshot of qurl-service/api/openapi.yaml — canonical API contract."

--- a/scripts/update-openapi-snapshot.sh
+++ b/scripts/update-openapi-snapshot.sh
@@ -26,6 +26,12 @@ fi
 # with an unrelated repo at ../qurl-service that happens to contain
 # api/openapi.yaml could silently snapshot from the wrong source — the
 # header SHA would be from their fork, not upstream.
+#
+# Intentionally permissive: matches any org's `qurl-service` repo, not
+# just layervai/qurl-service. Forks of qurl-service are legitimate dev
+# workflows, and the header SHA recorded in the snapshot is the
+# authoritative provenance that reviewers verify — this check exists to
+# catch "wrong repo entirely," not to gate on upstream identity.
 REMOTE_URL=$(git -C "$QURL_SERVICE_DIR" remote get-url origin 2>/dev/null || echo "")
 if ! printf '%s' "$REMOTE_URL" | grep -q -E '[:/]qurl-service(\.git)?$'; then
   echo "error: $QURL_SERVICE_DIR origin remote does not look like qurl-service:" >&2

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -11,30 +11,7 @@ import {
   TimeoutError,
   ValidationError,
 } from "./errors.js";
-
-function mockFetch(response: {
-  status: number;
-  body?: unknown;
-  headers?: Record<string, string>;
-}): typeof globalThis.fetch {
-  return vi.fn().mockResolvedValue({
-    ok: response.status >= 200 && response.status < 300,
-    status: response.status,
-    statusText: response.status === 200 ? "OK" : "Error",
-    headers: new Headers(response.headers ?? {}),
-    json: () => Promise.resolve(response.body),
-    text: () => Promise.resolve(JSON.stringify(response.body)),
-  } satisfies Partial<Response> as Response);
-}
-
-function createClient(fetchFn: typeof globalThis.fetch): QURLClient {
-  return new QURLClient({
-    apiKey: "lv_live_test",
-    baseUrl: "https://api.test.layerv.ai",
-    fetch: fetchFn,
-    maxRetries: 0,
-  });
-}
+import { mockFetch, createClient } from "./test-helpers.js";
 
 describe("QURLClient", () => {
   it("creates a QURL", async () => {

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -183,7 +183,27 @@ describe("OpenAPI contract", () => {
       const desc = Object.getOwnPropertyDescriptor(QURLClient.prototype, name);
       return typeof desc?.value === "function";
     });
-    expect(new Set(prototypeMethods)).toEqual(SDK_PUBLIC_METHODS);
+    const actual = new Set(prototypeMethods);
+    const missingFromSet = [...actual].filter((m) => !SDK_PUBLIC_METHODS.has(m));
+    const missingFromPrototype = [...SDK_PUBLIC_METHODS].filter((m) => !actual.has(m));
+    // Custom remediation message — vitest's default `toEqual` diff on Sets
+    // doesn't explain *what to do*. If this fires, the contributor needs
+    // to either add the method to SDK_PUBLIC_METHODS + write a contract
+    // case, or move it to INTERNAL_HELPERS if it's not a public API call.
+    if (missingFromSet.length || missingFromPrototype.length) {
+      throw new Error(
+        `Contract set drift:\n` +
+          (missingFromSet.length
+            ? `  New public method(s) on QURLClient.prototype: ${missingFromSet.join(", ")}\n` +
+              `    → add to SDK_PUBLIC_METHODS and add an it("…") case, ` +
+              `OR add to INTERNAL_HELPERS if not a user-facing API call.\n`
+            : "") +
+          (missingFromPrototype.length
+            ? `  Listed in SDK_PUBLIC_METHODS but missing from prototype: ${missingFromPrototype.join(", ")}\n` +
+              `    → either the method was removed/renamed in client.ts, or the name here is wrong.\n`
+            : ""),
+      );
+    }
   });
 
   // Each SDK public method → one call → captured (verb, url) must match

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -55,6 +55,10 @@ for (const [path, methods] of Object.entries(spec.paths)) {
 // `/v1/qurls/{id}` → `^/v1/qurls/[^/]+$`. Regex-escape the literal,
 // then un-escape and widen the `{param}` segments into single-segment
 // wildcards. Anchored so `/v1/qurls` does not also match `/v1/qurls/{id}`.
+// Single-segment widening (`[^/]+` not `.+`) is intentional — a template
+// like `/v1/qurls/{id}/mint_link` must match `/v1/qurls/abc/mint_link`
+// but NOT `/v1/qurls/abc/def/mint_link`, which would be a different
+// (and unintended) endpoint.
 function templateRegex(pathTemplate: string): RegExp {
   const escaped = pathTemplate
     .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
@@ -86,8 +90,17 @@ function assertSdkCallMatches(
         `Expected ${expectedVerb} ${expectedTemplate}.`,
     );
   }
+  // fetch() also accepts URL and Request instances, but client.ts only
+  // calls it with strings. A regression to URL/Request would make
+  // `new URL(rawUrl)` throw a confusing message — surface a clearer one.
+  if (typeof rawUrl !== "string") {
+    throw new Error(
+      `SDK called fetch with a ${typeof rawUrl}; contract test expects a string URL. ` +
+        `Expected ${expectedVerb} ${expectedTemplate}.`,
+    );
+  }
   const actualVerb = (init as RequestInit).method as Verb;
-  const actualPath = new URL(rawUrl as string).pathname;
+  const actualPath = new URL(rawUrl).pathname;
 
   // Layer 1: spec must declare the (verb, template) the test expects.
   const templateKey = `${expectedVerb} ${expectedTemplate}`;
@@ -300,6 +313,11 @@ describe("OpenAPI contract", () => {
     // The subtle case: if `create()` ever typo'd to POST /v1/resolve it
     // would be a spec-valid endpoint but the wrong contract. The helper
     // must catch this — membership-only checks silently would not.
+    //
+    // The error-string regex below is intentionally strict so that a
+    // copy edit to assertSdkCallMatches's error message breaks this test,
+    // forcing a reviewer to re-confirm the message is still operator-
+    // actionable. If you edit that message, update this regex too.
     const fetch = mockOk({ data: { target_url: "https://example.com" } });
     await client(fetch).resolve("at_y"); // actually calls POST /v1/resolve
     expect(() => assertSdkCallMatches(fetch, "POST", "/v1/qurls")).toThrow(

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -206,6 +206,33 @@ describe("OpenAPI contract", () => {
     }
   });
 
+  // Closes the last "silently slip past" gap: set-vs-prototype parity
+  // alone doesn't guarantee an it() case exists for every method —
+  // someone could add `foo` to SDK_PUBLIC_METHODS without writing the
+  // test. Parse this test file's own source and assert every listed
+  // method has at least one `it("<method>…"` declaration. Word-boundary
+  // aware (lookahead for whitespace or `(`) so `list` doesn't falsely
+  // match `listAll`.
+  it("every SDK_PUBLIC_METHOD has an it() case (test-file coverage)", () => {
+    const src = readFileSync(fileURLToPath(import.meta.url), "utf8");
+    const missing: string[] = [];
+    for (const method of SDK_PUBLIC_METHODS) {
+      // Escape the method name for safe regex interpolation (trivial
+      // today — all names are [a-zA-Z]+ — but future-proofs the check).
+      const escaped = method.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+      const re = new RegExp(`\\bit\\("${escaped}(?=[\\s("])`);
+      if (!re.test(src)) missing.push(method);
+    }
+    if (missing.length > 0) {
+      throw new Error(
+        `SDK_PUBLIC_METHODS listed but no matching it("<method>…") found: ` +
+          `${missing.join(", ")}. Add a contract case for each, or remove ` +
+          `the name from SDK_PUBLIC_METHODS (and INTERNAL_HELPERS if it's ` +
+          `no longer public).`,
+      );
+    }
+  });
+
   // Each SDK public method → one call → captured (verb, url) must match
   // the exact (verb, path) template below. Aliases (`listAll` wraps
   // `list`, `extend` wraps `update`) are still called separately because

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
-import { QURLClient } from "./client.js";
+import { mockFetch, createClient } from "./test-helpers.js";
 
 // Contract test: every SDK method must call the exact (verb, path) pair
 // that qurl-service's OpenAPI spec declares. Catches two failure modes:
@@ -56,12 +56,26 @@ function assertSdkCallMatches(
   fetchFn: typeof globalThis.fetch,
   expectedVerb: Verb,
   expectedTemplate: string,
+  callIndex: number = 0,
 ): void {
   const calls = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock.calls;
-  if (calls.length === 0) {
-    throw new Error(`SDK made no fetch call; expected ${expectedVerb} ${expectedTemplate}`);
+  if (calls.length <= callIndex) {
+    throw new Error(
+      `SDK made ${calls.length} fetch call(s); expected at least ${callIndex + 1} ` +
+        `(looking for ${expectedVerb} ${expectedTemplate})`,
+    );
   }
-  const [rawUrl, init] = calls[0];
+  const [rawUrl, init] = calls[callIndex];
+  // Guard against a future SDK method calling fetch(url) with no options —
+  // today every path in client.ts passes an `init` object, but the check is
+  // cheap insurance against a regression with a clearer error than the
+  // undefined-access TypeError a bare access would throw.
+  if (!init) {
+    throw new Error(
+      `SDK called fetch without an init object; cannot verify method. ` +
+        `Expected ${expectedVerb} ${expectedTemplate}.`,
+    );
+  }
   const actualVerb = (init as RequestInit).method as Verb;
   const actualPath = new URL(rawUrl as string).pathname;
 
@@ -84,25 +98,15 @@ function assertSdkCallMatches(
   }
 }
 
-function mockOk(body: unknown = { data: {}, meta: {} }): typeof globalThis.fetch {
-  return vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    statusText: "OK",
-    headers: new Headers(),
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body)),
-  } satisfies Partial<Response> as Response);
-}
+// `mockOk` + `client` wrap the shared helpers with contract-test defaults:
+// `status: 200` for `mockOk`, and the identifier `client` kept short since
+// every test in this file uses it once. Keeps the test bodies readable
+// without forking the underlying fixture — if a fixture ever changes
+// (e.g., the default baseUrl or apiKey), both test files move together.
+const mockOk = (body: unknown = { data: {}, meta: {} }): typeof globalThis.fetch =>
+  mockFetch({ status: 200, body });
 
-function client(fetchFn: typeof globalThis.fetch): QURLClient {
-  return new QURLClient({
-    apiKey: "lv_live_test",
-    baseUrl: "https://api.test.layerv.ai",
-    fetch: fetchFn,
-    maxRetries: 0,
-  });
-}
+const client = createClient;
 
 describe("OpenAPI contract", () => {
   it("snapshot parses and has paths", () => {
@@ -144,14 +148,43 @@ describe("OpenAPI contract", () => {
 
   it("listAll → GET /v1/qurls (via wrapped list)", async () => {
     const fetch = mockOk({ data: [], meta: { has_more: false } });
-    // Drive the generator to completion so `list` actually gets called.
-    // Using iterator-protocol `.next()` instead of `for…of` avoids
-    // declaring an unused loop binding that trips eslint.
+    // Drive the generator to completion so the underlying list() fires.
     const iter = client(fetch).listAll();
     while (!(await iter.next()).done) {
-      /* no-op — iteration itself is the contract being exercised. */
+      /* no-op */
     }
     assertSdkCallMatches(fetch, "GET", "/v1/qurls");
+  });
+
+  it("listAll multi-page → every page hits GET /v1/qurls", async () => {
+    // Two-page mock so the test covers the pagination path — a single-page
+    // exit would not exercise that every subsequent fetch also targets the
+    // same endpoint. Custom fetch instead of mockOk so call N can return
+    // a different body than call 0.
+    const fetch = vi
+      .fn()
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        json: async () => ({ data: [], meta: { has_more: true, next_cursor: "c2" } }),
+        text: async () => "",
+      }))
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        json: async () => ({ data: [], meta: { has_more: false } }),
+        text: async () => "",
+      })) as unknown as typeof globalThis.fetch;
+    const iter = client(fetch).listAll();
+    while (!(await iter.next()).done) {
+      /* no-op */
+    }
+    assertSdkCallMatches(fetch, "GET", "/v1/qurls", 0);
+    assertSdkCallMatches(fetch, "GET", "/v1/qurls", 1);
   });
 
   it("update → PATCH /v1/qurls/{id}", async () => {

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
+import { QURLClient } from "./client.js";
 import { mockFetch, createClient } from "./test-helpers.js";
 
 // Contract test: every SDK method must call the exact (verb, path) pair
@@ -35,10 +36,19 @@ const spec = parseYaml(readFileSync(snapshotPath, "utf8")) as OpenApiSpec;
 // "snapshot drift renamed our endpoint" failure mode. The per-test
 // templateRegex() closes the "SDK called a different (but spec-valid)
 // path" failure mode.
+//
+// OpenAPI path-item objects may carry non-verb keys (`summary`,
+// `description`, `parameters`, `servers`, `$ref`) — the snapshot does
+// use `parameters:` at the path-item level in at least two places.
+// Filter against the allowed verb set so those don't leak into
+// pathTemplates as nonsense entries like `PARAMETERS /v1/...`.
+const HTTP_VERBS = new Set<Lowercase<Verb>>(["get", "post", "patch", "put", "delete"]);
 const pathTemplates = new Set<string>();
 for (const [path, methods] of Object.entries(spec.paths)) {
   for (const verb of Object.keys(methods ?? {})) {
-    pathTemplates.add(`${verb.toUpperCase()} ${path}`);
+    if (HTTP_VERBS.has(verb as Lowercase<Verb>)) {
+      pathTemplates.add(`${verb.toUpperCase()} ${path}`);
+    }
   }
 }
 
@@ -108,10 +118,60 @@ const mockOk = (body: unknown = { data: {}, meta: {} }): typeof globalThis.fetch
 
 const client = createClient;
 
+// Hardcoded expected public API surface. Kept in lockstep with the `it()`
+// blocks below AND with QURLClient's prototype. The completeness test
+// below asserts this set equals the prototype's own methods (minus
+// constructor and `toJSON`, which is a diagnostic helper, not an API
+// call). Adding a new public method to QURLClient without extending this
+// set — and a matching contract case — fails CI, closing the "silently
+// slip past" class this PR is designed to close.
+const SDK_PUBLIC_METHODS: ReadonlySet<string> = new Set([
+  "create",
+  "get",
+  "list",
+  "listAll",
+  "update",
+  "extend",
+  "delete",
+  "mintLink",
+  "resolve",
+  "getQuota",
+]);
+
+// `toJSON` is a diagnostic helper (used by console.log/JSON.stringify),
+// not an API call — intentionally outside the contract set.
+const NON_API_PROTOTYPE_METHODS: ReadonlySet<string> = new Set(["constructor", "toJSON"]);
+
 describe("OpenAPI contract", () => {
   it("snapshot parses and has paths", () => {
     expect(Object.keys(spec.paths ?? {}).length).toBeGreaterThan(0);
     expect(pathTemplates.size).toBeGreaterThan(0);
+  });
+
+  it("SDK public methods match the contract-covered set (completeness)", () => {
+    const prototypeMethods = Object.getOwnPropertyNames(QURLClient.prototype).filter((name) => {
+      if (NON_API_PROTOTYPE_METHODS.has(name)) return false;
+      const desc = Object.getOwnPropertyDescriptor(QURLClient.prototype, name);
+      if (typeof desc?.value !== "function") return false;
+      // TypeScript's `private`/`protected` keywords erase at runtime, so
+      // visibility isn't introspectable. Filter by naming convention —
+      // the SDK uses lowercase identifiers for internal helpers like
+      // `request`, `rawRequest`, `parseError`, etc. — none of those are
+      // API calls. Anything added to this deny-list should be genuinely
+      // internal; a public method must not be listed here.
+      const INTERNAL_HELPERS = new Set([
+        "request",
+        "rawRequest",
+        "maskKey",
+        "log",
+        "parseError",
+        "parseRetryAfter",
+        "retryDelay",
+        "classifyFetchError",
+      ]);
+      return !INTERNAL_HELPERS.has(name);
+    });
+    expect(new Set(prototypeMethods)).toEqual(SDK_PUBLIC_METHODS);
   });
 
   // Each SDK public method → one call → captured (verb, url) must match

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { QURLClient } from "./client.js";
+
+// Contract test: every SDK method must call the exact (verb, path) pair
+// that qurl-service's OpenAPI spec declares. Catches two failure modes:
+//   1. SDK typos a path to something the spec doesn't have at all
+//      (the class PR #46 closed — /v1/qurl vs /v1/qurls).
+//   2. SDK typos a path to a DIFFERENT valid endpoint
+//      (subtler — e.g., create → POST /v1/resolve would be a valid spec
+//      path but the wrong contract; membership-only checks would pass).
+//
+// Snapshot lives at contract/openapi.snapshot.yaml — vendored (not
+// network-fetched) so this runs hermetically in CI. Regenerate via
+// scripts/update-openapi-snapshot.sh when qurl-service's spec moves.
+
+type Verb = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+type OpenApiSpec = {
+  paths: Record<string, Partial<Record<Lowercase<Verb>, unknown>>>;
+};
+
+const snapshotPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "contract",
+  "openapi.snapshot.yaml",
+);
+const spec = parseYaml(readFileSync(snapshotPath, "utf8")) as OpenApiSpec;
+
+// Set of `${verb} ${path}` strings lifted from the OpenAPI snapshot.
+// Used to assert the expected template exists in the spec — closes the
+// "snapshot drift renamed our endpoint" failure mode. The per-test
+// templateRegex() closes the "SDK called a different (but spec-valid)
+// path" failure mode.
+const pathTemplates = new Set<string>();
+for (const [path, methods] of Object.entries(spec.paths)) {
+  for (const verb of Object.keys(methods ?? {})) {
+    pathTemplates.add(`${verb.toUpperCase()} ${path}`);
+  }
+}
+
+// `/v1/qurls/{id}` → `^/v1/qurls/[^/]+$`. Regex-escape the literal,
+// then un-escape and widen the `{param}` segments into single-segment
+// wildcards. Anchored so `/v1/qurls` does not also match `/v1/qurls/{id}`.
+function templateRegex(pathTemplate: string): RegExp {
+  const escaped = pathTemplate
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\\\{[^}]+\\\}/g, "[^/]+");
+  return new RegExp(`^${escaped}$`);
+}
+
+function assertSdkCallMatches(
+  fetchFn: typeof globalThis.fetch,
+  expectedVerb: Verb,
+  expectedTemplate: string,
+): void {
+  const calls = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock.calls;
+  if (calls.length === 0) {
+    throw new Error(`SDK made no fetch call; expected ${expectedVerb} ${expectedTemplate}`);
+  }
+  const [rawUrl, init] = calls[0];
+  const actualVerb = (init as RequestInit).method as Verb;
+  const actualPath = new URL(rawUrl as string).pathname;
+
+  // Layer 1: spec must declare the (verb, template) the test expects.
+  const templateKey = `${expectedVerb} ${expectedTemplate}`;
+  if (!pathTemplates.has(templateKey)) {
+    throw new Error(
+      `Expected (verb, path) "${templateKey}" is not in qurl-service OpenAPI ` +
+        `snapshot. Either the SDK is wrong, or qurl-service's contract ` +
+        `changed — in which case regenerate contract/openapi.snapshot.yaml ` +
+        `via scripts/update-openapi-snapshot.sh.`,
+    );
+  }
+
+  // Layer 2: SDK must have actually called that specific template.
+  if (actualVerb !== expectedVerb || !templateRegex(expectedTemplate).test(actualPath)) {
+    throw new Error(
+      `SDK called ${actualVerb} ${actualPath}, expected ${expectedVerb} ${expectedTemplate}.`,
+    );
+  }
+}
+
+function mockOk(body: unknown = { data: {}, meta: {} }): typeof globalThis.fetch {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: new Headers(),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } satisfies Partial<Response> as Response);
+}
+
+function client(fetchFn: typeof globalThis.fetch): QURLClient {
+  return new QURLClient({
+    apiKey: "lv_live_test",
+    baseUrl: "https://api.test.layerv.ai",
+    fetch: fetchFn,
+    maxRetries: 0,
+  });
+}
+
+describe("OpenAPI contract", () => {
+  it("snapshot parses and has paths", () => {
+    expect(Object.keys(spec.paths ?? {}).length).toBeGreaterThan(0);
+    expect(pathTemplates.size).toBeGreaterThan(0);
+  });
+
+  // Each SDK public method → one call → captured (verb, url) must match
+  // the exact (verb, path) template below. Aliases (`listAll` wraps
+  // `list`, `extend` wraps `update`) are still called separately because
+  // the aliasing is inside the SDK; if an alias were ever rewired to a
+  // different path the test would catch it.
+
+  it("create → POST /v1/qurls", async () => {
+    const fetch = mockOk({
+      data: { resource_id: "r_x", qurl_link: "https://qurl.link/#at_y" },
+    });
+    await client(fetch).create({ target_url: "https://example.com" });
+    assertSdkCallMatches(fetch, "POST", "/v1/qurls");
+  });
+
+  it("get → GET /v1/qurls/{id}", async () => {
+    const fetch = mockOk({ data: { resource_id: "r_x" } });
+    await client(fetch).get("r_x");
+    assertSdkCallMatches(fetch, "GET", "/v1/qurls/{id}");
+  });
+
+  it("list → GET /v1/qurls", async () => {
+    const fetch = mockOk({ data: [], meta: { has_more: false } });
+    await client(fetch).list();
+    assertSdkCallMatches(fetch, "GET", "/v1/qurls");
+  });
+
+  it("list with query params → GET /v1/qurls (query stripped)", async () => {
+    const fetch = mockOk({ data: [], meta: { has_more: false } });
+    await client(fetch).list({ limit: 10, cursor: "c" });
+    assertSdkCallMatches(fetch, "GET", "/v1/qurls");
+  });
+
+  it("listAll → GET /v1/qurls (via wrapped list)", async () => {
+    const fetch = mockOk({ data: [], meta: { has_more: false } });
+    // Drive the generator to completion so `list` actually gets called.
+    // Using iterator-protocol `.next()` instead of `for…of` avoids
+    // declaring an unused loop binding that trips eslint.
+    const iter = client(fetch).listAll();
+    while (!(await iter.next()).done) {
+      /* no-op — iteration itself is the contract being exercised. */
+    }
+    assertSdkCallMatches(fetch, "GET", "/v1/qurls");
+  });
+
+  it("update → PATCH /v1/qurls/{id}", async () => {
+    const fetch = mockOk({ data: { resource_id: "r_x" } });
+    await client(fetch).update("r_x", { expires_in: "24h" });
+    assertSdkCallMatches(fetch, "PATCH", "/v1/qurls/{id}");
+  });
+
+  it("extend → PATCH /v1/qurls/{id} (alias of update)", async () => {
+    const fetch = mockOk({ data: { resource_id: "r_x" } });
+    await client(fetch).extend("r_x", { expires_in: "24h" });
+    assertSdkCallMatches(fetch, "PATCH", "/v1/qurls/{id}");
+  });
+
+  it("delete → DELETE /v1/qurls/{id}", async () => {
+    const fetch = mockOk();
+    await client(fetch).delete("r_x");
+    assertSdkCallMatches(fetch, "DELETE", "/v1/qurls/{id}");
+  });
+
+  it("mintLink → POST /v1/qurls/{id}/mint_link", async () => {
+    const fetch = mockOk({ data: { qurl_link: "https://qurl.link/#at_y" } });
+    await client(fetch).mintLink("r_x");
+    assertSdkCallMatches(fetch, "POST", "/v1/qurls/{id}/mint_link");
+  });
+
+  it("resolve → POST /v1/resolve", async () => {
+    const fetch = mockOk({ data: { target_url: "https://example.com" } });
+    await client(fetch).resolve("at_y");
+    assertSdkCallMatches(fetch, "POST", "/v1/resolve");
+  });
+
+  it("getQuota → GET /v1/quota", async () => {
+    const fetch = mockOk({ data: { plan: "free" } });
+    await client(fetch).getQuota();
+    assertSdkCallMatches(fetch, "GET", "/v1/quota");
+  });
+
+  // Anti-vacuous-pass guards. These validate the two failure modes the
+  // helper is designed to catch — if either regresses, this trips.
+
+  it("negative: expected template must exist in snapshot", async () => {
+    // Invoke something real so calls[0] is populated, then assert against
+    // a fabricated template that isn't in the spec.
+    const fetch = mockOk({ data: { plan: "free" } });
+    await client(fetch).getQuota();
+    expect(() => assertSdkCallMatches(fetch, "GET", "/v1/definitely-not-a-real-endpoint")).toThrow(
+      /is not in qurl-service OpenAPI snapshot/,
+    );
+  });
+
+  it("negative: SDK call to a different (but spec-valid) path fails", async () => {
+    // The subtle case: if `create()` ever typo'd to POST /v1/resolve it
+    // would be a spec-valid endpoint but the wrong contract. The helper
+    // must catch this — membership-only checks silently would not.
+    const fetch = mockOk({ data: { target_url: "https://example.com" } });
+    await client(fetch).resolve("at_y"); // actually calls POST /v1/resolve
+    expect(() => assertSdkCallMatches(fetch, "POST", "/v1/qurls")).toThrow(
+      /SDK called POST \/v1\/resolve, expected POST \/v1\/qurls/,
+    );
+  });
+});

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -155,6 +155,22 @@ const SDK_PUBLIC_METHODS: ReadonlySet<string> = new Set([
 // not an API call — intentionally outside the contract set.
 const NON_API_PROTOTYPE_METHODS: ReadonlySet<string> = new Set(["constructor", "toJSON"]);
 
+// Internal helpers on the prototype that are deliberately excluded from
+// the public API surface. TypeScript's `private`/`protected` keywords
+// erase at runtime, so visibility isn't introspectable — this deny-list
+// IS the classification. Anything added here must be genuinely internal;
+// a user-callable method belongs in SDK_PUBLIC_METHODS instead.
+const INTERNAL_HELPERS: ReadonlySet<string> = new Set([
+  "request",
+  "rawRequest",
+  "maskKey",
+  "log",
+  "parseError",
+  "parseRetryAfter",
+  "retryDelay",
+  "classifyFetchError",
+]);
+
 describe("OpenAPI contract", () => {
   it("snapshot parses and has paths", () => {
     expect(Object.keys(spec.paths ?? {}).length).toBeGreaterThan(0);
@@ -163,26 +179,9 @@ describe("OpenAPI contract", () => {
 
   it("SDK public methods match the contract-covered set (completeness)", () => {
     const prototypeMethods = Object.getOwnPropertyNames(QURLClient.prototype).filter((name) => {
-      if (NON_API_PROTOTYPE_METHODS.has(name)) return false;
+      if (NON_API_PROTOTYPE_METHODS.has(name) || INTERNAL_HELPERS.has(name)) return false;
       const desc = Object.getOwnPropertyDescriptor(QURLClient.prototype, name);
-      if (typeof desc?.value !== "function") return false;
-      // TypeScript's `private`/`protected` keywords erase at runtime, so
-      // visibility isn't introspectable. Filter by naming convention —
-      // the SDK uses lowercase identifiers for internal helpers like
-      // `request`, `rawRequest`, `parseError`, etc. — none of those are
-      // API calls. Anything added to this deny-list should be genuinely
-      // internal; a public method must not be listed here.
-      const INTERNAL_HELPERS = new Set([
-        "request",
-        "rawRequest",
-        "maskKey",
-        "log",
-        "parseError",
-        "parseRetryAfter",
-        "retryDelay",
-        "classifyFetchError",
-      ]);
-      return !INTERNAL_HELPERS.has(name);
+      return typeof desc?.value === "function";
     });
     expect(new Set(prototypeMethods)).toEqual(SDK_PUBLIC_METHODS);
   });
@@ -284,9 +283,18 @@ describe("OpenAPI contract", () => {
     assertSdkCallMatches(fetch, "POST", "/v1/qurls/{id}/mint_link");
   });
 
-  it("resolve → POST /v1/resolve", async () => {
+  it("resolve (string arg) → POST /v1/resolve", async () => {
     const fetch = mockOk({ data: { target_url: "https://example.com" } });
     await client(fetch).resolve("at_y");
+    assertSdkCallMatches(fetch, "POST", "/v1/resolve");
+  });
+
+  it("resolve (object arg) → POST /v1/resolve", async () => {
+    // resolve() overloads: string token OR ResolveInput object. Both must
+    // hit the same endpoint; a regression where the object form dispatched
+    // elsewhere would otherwise slip past the string-form test.
+    const fetch = mockOk({ data: { target_url: "https://example.com" } });
+    await client(fetch).resolve({ access_token: "at_y" });
     assertSdkCallMatches(fetch, "POST", "/v1/resolve");
   });
 

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,0 +1,32 @@
+import { vi } from "vitest";
+import { QURLClient } from "./client.js";
+
+// Shared test fixtures used by client.test.ts and contract.test.ts.
+// Keep this file test-only — tsconfig excludes *.test.ts but NOT
+// test-helpers.ts, so it would otherwise land in dist/. Filename +
+// tsconfig exclude in lockstep: if you rename this, update the
+// exclude pattern.
+
+export function mockFetch(response: {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}): typeof globalThis.fetch {
+  return vi.fn().mockResolvedValue({
+    ok: response.status >= 200 && response.status < 300,
+    status: response.status,
+    statusText: response.status === 200 ? "OK" : "Error",
+    headers: new Headers(response.headers ?? {}),
+    json: () => Promise.resolve(response.body),
+    text: () => Promise.resolve(JSON.stringify(response.body)),
+  } satisfies Partial<Response> as Response);
+}
+
+export function createClient(fetchFn: typeof globalThis.fetch): QURLClient {
+  return new QURLClient({
+    apiKey: "lv_live_test",
+    baseUrl: "https://api.test.layerv.ai",
+    fetch: fetchFn,
+    maxRetries: 0,
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "src/test-helpers.ts"]
 }


### PR DESCRIPTION
Closes #47.

## Summary

Unit tests in this repo mock \`fetch\` and assert what the SDK *constructs*, so they cannot catch drift between the SDK and the qurl-service backend. That's how PR #46's \`/v1/qurl\` vs \`/v1/qurls\` typo stayed latent — the test itself codified the wrong URL.

This PR adds a contract test that asserts every SDK public method calls the exact (verb, path) template qurl-service's OpenAPI spec declares, on a vendored snapshot of that spec.

## What changed

- **\`contract/openapi.snapshot.yaml\`** — ~4400 lines, vendored from \`qurl-service/api/openapi.yaml\`. The snapshot header records the source commit SHA (currently \`qurl-service@2585c0e\`) so reviewers see exactly which version of the backend contract the SDK was last validated against. Hermetic by design: no network fetch at test time.
- **\`scripts/update-openapi-snapshot.sh\`** — one-shot regen script. Uses \`git show\` against a local qurl-service checkout (\`../qurl-service\` by default, override with \`QURL_SERVICE_DIR\`), takes an optional ref arg (tag/SHA/branch), resolves it to an immutable commit SHA, and writes the snapshot with that SHA in the header.
- **\`src/contract.test.ts\`** — 14 test cases. For each of the 10 SDK public methods, mocks fetch, invokes the method, and asserts both:
  1. The expected \`(verb, template)\` exists in the OpenAPI snapshot (catches snapshot drift — qurl-service renamed/moved/removed an endpoint the SDK uses).
  2. The SDK actually called THAT specific template, not just any spec-valid path (catches the subtler typo class — \`create() → POST /v1/resolve\` would be a valid endpoint but the wrong contract).
- Two negative test cases lock the helper's two failure-mode messages so it can't silently regress into a vacuous pass.
- **\`CONTRIBUTING.md\`** — new \"OpenAPI Contract Snapshot\" section covering the regen flow.
- **\`package.json\`** — adds \`yaml\` as a dev-dependency (the only new dep, test-time only; \`tsconfig.json\` already excludes \`**/*.test.ts\` and \`package.json\` only ships \`dist/\`, so the snapshot + test don't bloat the published package).

## Why this design

Two failure modes to catch, both seen in the PR #46 postmortem:

| Failure mode | What gets caught |
|---|---|
| **Path renamed upstream** (e.g. qurl-service renames \`/v1/qurls\` to \`/v1/qurl_resources\`) | Layer 1 assertion — expected template must exist in snapshot |
| **SDK typo'd to a different endpoint** (e.g. \`create → POST /v1/resolve\` — both valid, wrong contract) | Layer 2 assertion — SDK must call THE expected template |

Verified empirically before push:
- Flipping \`client.ts:118\` to \`POST /v1/qurl\` (the PR #46 case) → test fails: \`Expected (verb, path) \"POST /v1/qurl\" is not in qurl-service OpenAPI snapshot\`.
- Flipping it to \`POST /v1/resolve\` (the subtler case) → test fails: \`SDK called POST /v1/resolve, expected POST /v1/qurls\`.

## Commit-type choice

\`test:\` — Release Please's node release-type does not version-bump on \`test:\`, which is correct here: no user-visible API change, pure test coverage.

## Test plan

- [x] \`npm test\` — 62/62 passing (48 existing + 14 new contract cases).
- [x] \`npm run lint\` — clean.
- [x] \`npm run format:check\` — clean.
- [x] \`npm run build\` — clean (tsc excludes \`**/*.test.ts\` and the snapshot yaml, so \`dist/\` is unchanged).
- [x] Commit GPG-signed.
- [x] Regression experiments both fail the test with precise error messages (documented above).
- [x] Regen script idempotent: running it twice with no intervening backend change produces no diff.
- [ ] CI \`test\` + age-checks green on this PR.
- [ ] After merge: if qurl-service changes an endpoint the SDK uses, regenerating the snapshot will make this test fail, forcing SDK + snapshot to move together.

## Rollback

Plain revert. Test-only addition; no runtime behavior change. \`dist/\` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)