### PR TITLE
docs: rebrand QURL → qURL across user-facing surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             *) TRIGGER_TEXT="$GH_EVENT_NAME" ;;
           esac
 
-          HEADER="QURL TypeScript SDK Build"
+          HEADER="qURL TypeScript SDK Build"
           case "$TEST_RESULT" in
             success)  COLOR="#36a64f"; EMOJI=":white_check_mark:"; STATUS_TEXT="successful" ;;
             failure)  COLOR="#dc3545"; EMOJI=":x:";                STATUS_TEXT="failed" ;;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 ## Project
 
-TypeScript SDK for the QURL API (`npm install @layerv/qurl`). Extracted from `layervai/qurl-integrations`.
+TypeScript SDK for the qURL API (`npm install @layerv/qurl`). Extracted from `layervai/qurl-integrations`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![CI](https://github.com/layervai/qurl-typescript/actions/workflows/ci.yml/badge.svg)](https://github.com/layervai/qurl-typescript/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/layervai/qurl-typescript)](LICENSE)
 
-TypeScript SDK for the [qURL API](https://docs.layerv.ai) — secure, time-limited access links for AI agents.
+TypeScript SDK for the [qURL™ API](https://docs.layerv.ai) — secure, time-limited access links for AI agents.
+
+> **Quantum URL (qURL)** · The internet has a hidden layer. This is how you enter.
 
 ## Why qURL?
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![CI](https://github.com/layervai/qurl-typescript/actions/workflows/ci.yml/badge.svg)](https://github.com/layervai/qurl-typescript/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/layervai/qurl-typescript)](LICENSE)
 
-TypeScript SDK for the [QURL API](https://docs.layerv.ai) — secure, time-limited access links for AI agents.
+TypeScript SDK for the [qURL API](https://docs.layerv.ai) — secure, time-limited access links for AI agents.
 
-## Why QURL?
+## Why qURL?
 
-AI agents need to access protected resources — APIs, databases, internal tools — but giving them permanent credentials is a security risk. QURL creates time-limited, auditable access links that expire automatically. The SDK handles authentication, retries, pagination, and error handling so you can focus on your agent logic.
+AI agents need to access protected resources — APIs, databases, internal tools — but giving them permanent credentials is a security risk. qURL creates time-limited, auditable access links that expire automatically. The SDK handles authentication, retries, pagination, and error handling so you can focus on your agent logic.
 
 ## Installation
 
@@ -57,12 +57,12 @@ console.log(`Access granted to ${access.target_url} for ${access.access_grant?.e
 | Method | Description |
 |--------|-------------|
 | `create(input)` | Create a protected link |
-| `get(id)` | Get QURL details |
-| `list(input?)` | List QURLs (single page) |
-| `listAll(input?)` | Iterate all QURLs (auto-paginating) |
-| `delete(id)` | Revoke a QURL |
+| `get(id)` | Get qURL details |
+| `list(input?)` | List qURLs (single page) |
+| `listAll(input?)` | Iterate all qURLs (auto-paginating) |
+| `delete(id)` | Revoke a qURL |
 | `extend(id, input)` | Extend expiration |
-| `update(id, input)` | Update QURL properties |
+| `update(id, input)` | Update qURL properties |
 | `mintLink(id, input?)` | Mint a new access link |
 | `resolve(input)` | Resolve token + open firewall |
 | `getQuota()` | Get quota/usage info |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@layerv/qurl",
   "version": "0.1.0",
-  "description": "TypeScript SDK for the qURL API - secure, time-limited access links",
+  "description": "TypeScript SDK for the qURL™ API — secure, time-limited access links. Quantum URL is how you enter the hidden layer of the internet.",
   "type": "module",
   "sideEffects": false,
   "main": "./dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@layerv/qurl",
   "version": "0.1.0",
-  "description": "TypeScript SDK for the QURL API - secure, time-limited access links",
+  "description": "TypeScript SDK for the qURL API - secure, time-limited access links",
   "type": "module",
   "sideEffects": false,
   "main": "./dist/cjs/index.js",

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -14,7 +14,7 @@ import {
 import { mockFetch, createClient } from "./__tests__/test-helpers.js";
 
 describe("QURLClient", () => {
-  it("creates a QURL", async () => {
+  it("creates a qURL", async () => {
     const fetch = mockFetch({
       status: 201,
       body: {
@@ -42,7 +42,7 @@ describe("QURLClient", () => {
     );
   });
 
-  it("gets a QURL with access tokens", async () => {
+  it("gets a qURL with access tokens", async () => {
     const fetch = mockFetch({
       status: 200,
       body: {
@@ -93,7 +93,7 @@ describe("QURLClient", () => {
     expect(result.access_tokens![1].one_time_use).toBe(true);
   });
 
-  it("gets a QURL without access tokens", async () => {
+  it("gets a qURL without access tokens", async () => {
     const fetch = mockFetch({
       status: 200,
       body: {
@@ -115,7 +115,7 @@ describe("QURLClient", () => {
     expect(result.access_tokens).toBeUndefined();
   });
 
-  it("lists QURLs", async () => {
+  it("lists qURLs", async () => {
     const fetch = mockFetch({
       status: 200,
       body: {
@@ -157,14 +157,14 @@ describe("QURLClient", () => {
     );
   });
 
-  it("deletes a QURL", async () => {
+  it("deletes a qURL", async () => {
     const fetch = mockFetch({ status: 204 });
     const client = createClient(fetch);
 
     await expect(client.delete("r_abc123def45")).resolves.toBeUndefined();
   });
 
-  it("extends a QURL", async () => {
+  it("extends a qURL", async () => {
     const fetch = mockFetch({
       status: 200,
       body: {
@@ -184,7 +184,7 @@ describe("QURLClient", () => {
     expect(result.expires_at).toBe("2026-03-20T10:00:00Z");
   });
 
-  it("updates a QURL description", async () => {
+  it("updates a qURL description", async () => {
     const fetch = mockFetch({
       status: 200,
       body: {
@@ -248,7 +248,7 @@ describe("QURLClient", () => {
     expect((result as Record<string, unknown>).qurls).toBeUndefined();
   });
 
-  it("resolves a QURL token", async () => {
+  it("resolves a qURL token", async () => {
     const fetch = mockFetch({
       status: 200,
       body: {

--- a/src/client.ts
+++ b/src/client.ts
@@ -48,7 +48,7 @@ interface ApiErrorEnvelope {
   meta?: { request_id?: string };
 }
 
-/** QURL API client. */
+/** qURL API client. */
 export class QURLClient {
   private readonly baseUrl: string;
   private readonly apiKey: string;
@@ -113,7 +113,7 @@ export class QURLClient {
 
   // --- Public API ---
 
-  /** Create a new QURL. */
+  /** Create a new qURL. */
   async create(input: CreateInput): Promise<CreateOutput> {
     return this.request<CreateOutput>("POST", "/v1/qurls", input);
   }
@@ -128,7 +128,7 @@ export class QURLClient {
   }
 
   /**
-   * Lists protected URLs. Each QURL groups access tokens sharing the same target URL.
+   * Lists protected URLs. Each qURL groups access tokens sharing the same target URL.
    * Note: list items include qurl_count but not access_tokens (too expensive at scale).
    */
   async list(input: ListInput = {}): Promise<ListOutput> {
@@ -149,7 +149,7 @@ export class QURLClient {
     };
   }
 
-  /** Iterate over all QURLs, automatically paginating. */
+  /** Iterate over all qURLs, automatically paginating. */
   async *listAll(input: Omit<ListInput, "cursor"> = {}): AsyncGenerator<QURL, void, undefined> {
     let cursor: string | undefined;
     do {
@@ -161,13 +161,13 @@ export class QURLClient {
     } while (cursor);
   }
 
-  /** Delete (revoke) a QURL. */
+  /** Delete (revoke) a qURL. */
   async delete(id: string): Promise<void> {
     await this.rawRequest("DELETE", `/v1/qurls/${encodeURIComponent(id)}`);
   }
 
   /**
-   * Extend a QURL's expiration.
+   * Extend a qURL's expiration.
    *
    * Convenience method — equivalent to `update(id, input)`.
    */
@@ -175,7 +175,7 @@ export class QURLClient {
     return this.update(id, input);
   }
 
-  /** Update a QURL — extend expiration, change description, etc. */
+  /** Update a qURL — extend expiration, change description, etc. */
   async update(id: string, input: UpdateInput): Promise<QURL> {
     const raw = await this.request<QURL & { qurls?: AccessToken[] }>(
       "PATCH",
@@ -185,13 +185,13 @@ export class QURLClient {
     return QURLClient.mapQurlsField(raw);
   }
 
-  /** Mint a new access link for a QURL. */
+  /** Mint a new access link for a qURL. */
   async mintLink(id: string, input?: MintInput): Promise<MintOutput> {
     return this.request<MintOutput>("POST", `/v1/qurls/${encodeURIComponent(id)}/mint_link`, input);
   }
 
   /**
-   * Resolve a QURL access token (headless).
+   * Resolve a qURL access token (headless).
    *
    * Triggers an NHP knock to open firewall access for the caller's IP.
    * Requires `qurl:resolve` scope on the API key.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,6 @@
 import type { QURLErrorData } from "./types.js";
 
-/** Base error thrown by the QURL API client. Catch this to handle all SDK errors. */
+/** Base error thrown by the qURL API client. Catch this to handle all SDK errors. */
 export class QURLError extends Error {
   readonly status: number;
   readonly code: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-/** Access control policy for a QURL. */
+/** Access control policy for a qURL. */
 export interface AccessPolicy {
   ip_allowlist?: string[];
   ip_denylist?: string[];
@@ -8,7 +8,7 @@ export interface AccessPolicy {
   user_agent_deny_regex?: string;
 }
 
-/** An individual access token within a QURL. */
+/** An individual access token within a qURL. */
 export interface AccessToken {
   /** Display identifier for this token (q_ prefix). */
   qurl_id: string;
@@ -24,7 +24,7 @@ export interface AccessToken {
   expires_at: string;
 }
 
-/** A QURL resource as returned by the API. */
+/** A qURL resource as returned by the API. */
 export interface QURL {
   resource_id: string;
   target_url: string;
@@ -39,7 +39,7 @@ export interface QURL {
   expires_at?: string;
 }
 
-/** Input for creating a QURL. */
+/** Input for creating a qURL. */
 export interface CreateInput {
   target_url: string;
   expires_in?: string;
@@ -51,7 +51,7 @@ export interface CreateInput {
   custom_domain?: string;
 }
 
-/** Response from creating a QURL. */
+/** Response from creating a qURL. */
 export interface CreateOutput {
   resource_id: string;
   qurl_link: string;
@@ -60,7 +60,7 @@ export interface CreateOutput {
   one_time_use?: boolean;
 }
 
-/** Input for listing QURLs. */
+/** Input for listing qURLs. */
 export interface ListInput {
   limit?: number;
   cursor?: string;
@@ -69,20 +69,20 @@ export interface ListInput {
   sort?: string;
 }
 
-/** Response from listing QURLs. */
+/** Response from listing qURLs. */
 export interface ListOutput {
   qurls: QURL[];
   next_cursor?: string;
   has_more: boolean;
 }
 
-/** Input for extending a QURL. */
+/** Input for extending a qURL. */
 export interface ExtendInput {
   extend_by?: string;
   expires_at?: string;
 }
 
-/** Input for updating a QURL — extend expiration, change description, etc. */
+/** Input for updating a qURL — extend expiration, change description, etc. */
 export interface UpdateInput {
   extend_by?: string;
   expires_at?: string;
@@ -101,7 +101,7 @@ export interface MintOutput {
   expires_at?: string;
 }
 
-/** Input for headless QURL resolution. */
+/** Input for headless qURL resolution. */
 export interface ResolveInput {
   access_token: string;
 }
@@ -141,7 +141,7 @@ export interface Quota {
   };
 }
 
-/** API error from the QURL service (RFC 7807). */
+/** API error from the qURL service (RFC 7807). */
 export interface QURLErrorData {
   status: number;
   code: string;


### PR DESCRIPTION
## Summary

Updates the brand spelling to **qURL** (case-sensitive) across user-visible strings, documentation, and JSDoc comments.

## Why

The product brand is `qURL`. README, the npm-published `package.json` `description`, JSDoc surfaces (which IDEs and TypeDoc render verbatim), and the test reporter output were inconsistently spelled `QURL`. This brings them in line.

## What changed

- `README.md`, `CLAUDE.md`, `package.json` description
- JSDoc `/** … */` comments in `src/{client,errors,types}.ts`
- Test description strings (`it("creates a qURL", …)`) for consistent reporter output
- CI workflow Slack notify header

## What was intentionally not changed

Identifier-style references kept as-is to preserve the public API:

- Class names: `QURL`, `QURLClient`, `QURLError`, `QURLErrorData`, plus all error subclasses (`AuthenticationError`, `AuthorizationError`, `NotFoundError`, `ValidationError`, `RateLimitError`, `ServerError`, `NetworkError`, `TimeoutError`)
- Field names: `qurl_id`, `qurl_link`, `qurl_site`, `qurl_count`, `qurls`, plus quota fields
- npm package name (`@layerv/qurl`)
- Import statements and CJS/ESM smoke tests (which assert on `typeof QURLClient === "function"`)
- `contract/openapi.snapshot.yaml` — synced from upstream OpenAPI spec; will pick up the rebrand when upstream lands

A few test mock fixtures keep `"detail": "QURL not found"` because they mirror upstream API responses; these will be updated alongside the upstream qurl-service rebrand to keep mocks accurate.

## Test plan

- [x] `npm run build` passes (ESM + CJS)
- [x] `npm run format:check` clean
- [x] `npm test` — 67/67 vitest tests pass
- [x] Grep verification: no `QURL` / `Qurl` left in prose contexts