### PR TITLE
ci: bump ops-routines-workflows shims to v0.6.1 + enable PR comments

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -37,8 +37,20 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@39fcb54fc36ea7b6032e138bd8b57647f2bb32f0 # v0.4.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     with:
       min_age_days: 7
+      # Post a sticky PR comment when an age-check fails, listing each
+      # pin with its eligible-after date and days remaining. The PR
+      # author / reviewer sees the retry-after date inline on the PR
+      # instead of having to click into the run log to find it. Sticky
+      # comment is updated in place on re-runs and deleted on a clean
+      # pass; soft-fails to a `::notice` if the token can't write.
+      comment_on_failure: true
     permissions:
       contents: read
+      # Required for `comment_on_failure: true` to actually post.
+      # Dependabot PRs default to read-only and need this grant
+      # explicitly. Without it, the workflow still fails the age check
+      # correctly — only the inline comment is suppressed.
+      pull-requests: write

--- a/.github/workflows/dependency-age-check-npm.yml
+++ b/.github/workflows/dependency-age-check-npm.yml
@@ -37,8 +37,20 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-npm.yml@3f4ce1fdeb5d2f6f66b0b2c7d0ba42efce7212bc # v0.2.0
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-npm.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     with:
       min_age_days: 7
+      # Post a sticky PR comment when an age-check fails, listing each
+      # pin with its eligible-after date and days remaining. The PR
+      # author / reviewer sees the retry-after date inline on the PR
+      # instead of having to click into the run log to find it. Sticky
+      # comment is updated in place on re-runs and deleted on a clean
+      # pass; soft-fails to a `::notice` if the token can't write.
+      comment_on_failure: true
     permissions:
       contents: read
+      # Required for `comment_on_failure: true` to actually post.
+      # Dependabot PRs default to read-only and need this grant
+      # explicitly. Without it, the workflow still fails the age check
+      # correctly — only the inline comment is suppressed.
+      pull-requests: write

--- a/.github/workflows/issue-priority.yml
+++ b/.github/workflows/issue-priority.yml
@@ -48,6 +48,6 @@ jobs:
     # reusable's own `sender.type != 'Bot'` check short-circuits them
     # before setFailed — net effect is a near-instant no-op run.
     if: ${{ github.actor != 'github-actions[bot]' }}
-    uses: layervai/ops-routines-workflows/.github/workflows/issue-priority.yml@39fcb54fc36ea7b6032e138bd8b57647f2bb32f0 # v0.4.0
+    uses: layervai/ops-routines-workflows/.github/workflows/issue-priority.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
     permissions:
       issues: write

--- a/.github/workflows/validate-issue-templates.yml
+++ b/.github/workflows/validate-issue-templates.yml
@@ -35,4 +35,4 @@ permissions:
 
 jobs:
   validate-templates:
-    uses: layervai/ops-routines-workflows/.github/workflows/validate-issue-templates.yml@39fcb54fc36ea7b6032e138bd8b57647f2bb32f0 # v0.4.0
+    uses: layervai/ops-routines-workflows/.github/workflows/validate-issue-templates.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1


### PR DESCRIPTION
## Why

When dependabot bumps a recently-released action / Go module / docker base image / npm or pip package, the age-check workflow correctly blocks merge until the pin clears the quarantine. Until v0.6.1 the eligible-after date was only in the run log; now it lands as a sticky comment on the PR itself — one row per too-new pin (id, age, eligible date, days remaining).

## What

For each age-check shim (`.github/workflows/dependency-age-check-*.yml`):
1. Bump pinned reusable to **v0.6.1** (`4edea7408d64f424780e08f68a54000308817a08`).
2. Set `comment_on_failure: true`.
3. Grant `pull-requests: write` at the calling job. **This is what makes the comment actually post on Dependabot PRs** (Dependabot's token defaults to read-only; without the grant the post-step soft-fails to a `::notice` and the comment is suppressed — the check itself still runs and blocks merge correctly).

For non-age-check shims (issue-priority / validate-issue-templates / dispatch-deploy if present): pin bump only. v0.6.1's dist for those reusables is byte-identical to earlier versions; the bump is purely version-alignment.

## What is unchanged

- The age-check logic itself (still blocks new pins under the configured `min_age_days`).
- The `age-check-bypass` label still works.
- The required-check job names are unchanged in v0.6.1, so branch protection will not trip.
- No behavior change for non-failing PRs.

## Refs

- v0.6.1 release: https://github.com/layervai/ops-routines-workflows/releases/tag/v0.6.1
