### PR TITLE
ci: gate npm publish on `npm-publish` environment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,6 +39,7 @@ jobs:
     needs: [release-please, test]
     if: needs.release-please.outputs.release_created
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Adds `environment: npm-publish` to the `publish` job in `release-please.yml`. This is half of a defense-in-depth measure against the TanStack-style supply-chain attack class (GHSA-g7cv-rxg3-hmpx / CVE-2026-45321): a workflow-compromise path that succeeds in invoking the publish job would be blocked at the environment gate before `NPM_TOKEN` or the OIDC token are exposed.

## What this PR does
- Adds `environment: npm-publish` to the publish job.

## What this PR does NOT do (admin follow-up)
The environment doesn't exist yet. After merge, an admin needs to:
1. Settings -> Environments -> New environment -> `npm-publish`
2. Add **Required reviewers** (recommend: a small ops group)
3. **Restrict deployment branches** to `main` only (environment-level enforcement, not just the workflow trigger)
4. **Move `NPM_TOKEN` from a repository secret to an environment secret on `npm-publish`.** Without this, a separate compromised workflow could still reference `secrets.NPM_TOKEN` and exfiltrate the token without ever invoking the publish job. Scoping to the environment is what makes the human gate load-bearing for token exposure.

Until steps 2-4 are configured, the workflow change is a no-op -- the env auto-creates on first run with no protection.

Optional hardening: add a short wait timer (a few minutes) on the environment in addition to required reviewers, giving an extra window to cancel an unexpected publish.

## Context
We already have these supply-chain defenses on this repo:
- `.npmrc` with `min-release-age=7` + `ignore-scripts=true`
- `npm ci` (lockfile-bound) in CI
- `--provenance` on publish (Sigstore-signed)
- SHA-pinned actions enforced by `age-check-actions`
- Trigger is `push: branches: [main]` only (no `pull_request_target` path into publish)

This PR adds an out-of-band human gate so even if all the above are bypassed, a publish requires a reviewer click.

## Test plan
- [ ] CI green on this PR
- [ ] Admin: create `npm-publish` environment with required reviewers + main-only deployment branches + scoped `NPM_TOKEN`
- [ ] Verify next release-please-driven publish stalls on environment approval