### PR TITLE
ci(deps): bump ops-routines-workflows from v0.6.1 to v0.6.2

### DIFF
--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -37,7 +37,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-actions.yml@ca41c7123c507ad45331a723851da6c010541154 # v0.6.2
     with:
       min_age_days: 7
       # Post a sticky PR comment when an age-check fails, listing each

--- a/.github/workflows/dependency-age-check-npm.yml
+++ b/.github/workflows/dependency-age-check-npm.yml
@@ -37,7 +37,7 @@ jobs:
     # only if/name/needs/permissions/secrets/strategy/uses/with/concurrency
     # are valid on a job that calls a reusable workflow. The reusable
     # workflow itself sets `timeout-minutes: 5` internally.
-    uses: layervai/ops-routines-workflows/.github/workflows/age-check-npm.yml@4edea7408d64f424780e08f68a54000308817a08 # v0.6.1
+    uses: layervai/ops-routines-workflows/.github/workflows/age-check-npm.yml@ca41c7123c507ad45331a723851da6c010541154 # v0.6.2
     with:
       min_age_days: 7
       # Post a sticky PR comment when an age-check fails, listing each


### PR DESCRIPTION
## Why

Bumps the ops-routines-workflows age-check reusables from v0.6.1 to v0.6.2.

v0.6.2 fixes a gap in the v0.6.0 sticky-comment feature: previously only "too new" pins surfaced as a PR comment. Transient upstream failures (gh api / docker registry / proxy / pypi / npmjs unreachable) left PRs with a red required check and no PR-level explanation. v0.6.2 renders unverifiable failures as a sticky comment too, with re-run guidance instead of an eligible-after date.

Hardening folded in alongside:
- `record_unverifiable` strips `\t\n|` from `reason` so callers forwarding upstream error text can't break the markdown table layout.
- Same pin landing as both kinds (transient mid-run flake across two changed files) is deduped.
- `awk` failure under `set -euo pipefail` no longer silently suppresses the comment.

Upstream: https://github.com/layervai/ops-routines-workflows/releases/tag/v0.6.2

## Test plan

- [ ] CI green on this PR.