### PR TITLE
ci: publish @layervai/qurl with trusted publishing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,7 @@ body:
     id: version
     attributes:
       label: Package version
-      description: The installed `@layerv/qurl` version. Check `package.json` or run `npm list @layerv/qurl`.
+      description: The installed `@layervai/qurl` version. Check `package.json` or run `npm list @layervai/qurl`.
       placeholder: e.g. 0.3.x
     validations:
       required: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,13 +3,27 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref_name:
+        description: "Full 40-character commit SHA to publish to npm"
+        required: true
+        type: string
 
 permissions:
   contents: write
   pull-requests: write
 
+env:
+  # Trusted publishing requires npm >= 11.5.1; pin a known-good CLI past the
+  # repo's dependency-age fence and use it consistently before publish. Future
+  # bumps must also be old enough for .npmrc's min-release-age gate, including
+  # if the runner's bundled npm starts honoring that gate during bootstrap.
+  NPM_VERSION: "11.10.0"
+
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -23,35 +37,97 @@ jobs:
 
   test:
     needs: release-please
-    if: needs.release-please.outputs.release_created
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
+      # Load-bearing guard: keep this validation inline in the trusted workflow,
+      # not in code loaded from the operator-selected ref.
+      - name: Validate manual publish ref
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REF_NAME: ${{ github.event.inputs.ref_name }}
+        run: |
+          if [[ ! "$REF_NAME" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "ref_name must be a full 40-character commit SHA"
+            exit 1
+          fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.ref_name || needs.release-please.outputs.tag_name }}
+          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && '0' || '1' }}
+      - name: Validate manual publish ancestry
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REF_NAME: ${{ github.event.inputs.ref_name }}
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$REF_NAME" origin/main; then
+            echo "ref_name must be an ancestor of main"
+            exit 1
+          fi
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
+      - run: npm install -g npm@${{ env.NPM_VERSION }}
       - run: npm ci
       - run: npm run build
+      - run: npm run smoke:dist
       - run: npm test
 
   publish:
     needs: [release-please, test]
-    if: needs.release-please.outputs.release_created
+    if: ${{ !cancelled() && needs.test.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true') }}
     runs-on: ubuntu-latest
+    # Serialize only the npm publish boundary; release-please maintenance and
+    # validation jobs can still run while a manual publish waits for approval.
+    concurrency:
+      group: npm-publish
+      cancel-in-progress: false
+    # Manual dispatch can publish any approved ref; keep this environment's
+    # required-reviewer, no-self-review, and no-admin-bypass rules intact.
     environment: npm-publish
     permissions:
       contents: read
       id-token: write
     steps:
+      # Load-bearing guard: keep this validation inline in the trusted workflow,
+      # not in code loaded from the operator-selected ref.
+      - name: Validate manual publish ref
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REF_NAME: ${{ github.event.inputs.ref_name }}
+        run: |
+          if [[ ! "$REF_NAME" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "ref_name must be a full 40-character commit SHA"
+            exit 1
+          fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.ref_name || needs.release-please.outputs.tag_name }}
+          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && '0' || '1' }}
+      - name: Validate manual publish ancestry
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          REF_NAME: ${{ github.event.inputs.ref_name }}
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$REF_NAME" origin/main; then
+            echo "ref_name must be an ancestor of main"
+            exit 1
+          fi
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
-          cache: "npm"
+          # setup-node v6 auto-caches package managers by default; keep the
+          # privileged publish job independent of restored dependency caches.
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
+      - run: npm install -g npm@${{ env.NPM_VERSION }}
       - run: npm ci
+      # .npmrc disables lifecycle scripts, so build and smoke explicitly here.
       - run: npm run build
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm run smoke:dist
+      - run: npm publish --provenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 ## Project
 
-TypeScript SDK for the qURL API (`npm install @layerv/qurl`). Extracted from `layervai/qurl-integrations`.
+TypeScript SDK for the qURL API (`npm install @layervai/qurl`). Extracted from `layervai/qurl-integrations`.
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing to `@layerv/qurl`!
+Thanks for your interest in contributing to `@layervai/qurl`!
 
 ## Development Setup
 
@@ -36,7 +36,7 @@ points each condition (`import`, `require`) at its matching build, with
 per-condition `types` so `moduleResolution: Node16` consumers get the
 right `.d.ts`.
 
-`smoke/cjs.cjs` and `smoke/esm.mjs` self-reference `@layerv/qurl` and
+`smoke/cjs.cjs` and `smoke/esm.mjs` self-reference `@layervai/qurl` and
 exercise both entry points end-to-end; `smoke/parity.mjs` additionally
 asserts both builds export the same runtime name set. CI runs all three
 after the build. These are the load-bearing checks that the consumer-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# @layerv/qurl
+# @layervai/qurl
 
-[![npm](https://img.shields.io/npm/v/@layerv/qurl)](https://www.npmjs.com/package/@layerv/qurl)
+[![npm](https://img.shields.io/npm/v/@layervai/qurl)](https://www.npmjs.com/package/@layervai/qurl)
 [![CI](https://github.com/layervai/qurl-typescript/actions/workflows/ci.yml/badge.svg)](https://github.com/layervai/qurl-typescript/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/layervai/qurl-typescript)](LICENSE)
 
@@ -15,15 +15,15 @@ AI agents need to access protected resources — APIs, databases, internal tools
 ## Installation
 
 ```bash
-npm install @layerv/qurl
+npm install @layervai/qurl
 ```
 
-Requires Node.js 18+. Both `import { QURLClient } from '@layerv/qurl'` (ESM) and `const { QURLClient } = require('@layerv/qurl')` (CJS) work.
+Requires Node.js 18+. Both `import { QURLClient } from '@layervai/qurl'` (ESM) and `const { QURLClient } = require('@layervai/qurl')` (CJS) work.
 
 ## Quick Start
 
 ```typescript
-import { QURLClient } from '@layerv/qurl';
+import { QURLClient } from '@layervai/qurl';
 
 const client = new QURLClient({ apiKey: 'lv_live_xxx' });
 
@@ -131,7 +131,7 @@ import {
   NotFoundError,
   RateLimitError,
   ValidationError,
-} from '@layerv/qurl';
+} from '@layervai/qurl';
 
 try {
   await client.create({ target_url: '' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@layerv/qurl",
+  "name": "@layervai/qurl",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@layerv/qurl",
+      "name": "@layervai/qurl",
       "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@layerv/qurl",
+  "name": "@layervai/qurl",
   "version": "0.2.0",
   "description": "TypeScript SDK for the qURL™ API — secure, time-limited access links. Quantum URL is how you enter the hidden layer of the internet.",
   "type": "module",
@@ -32,7 +32,7 @@
   },
   "keywords": [
     "qurl",
-    "layerv",
+    "layervai",
     "security",
     "ai-agents",
     "zero-trust"

--- a/smoke/cjs.cjs
+++ b/smoke/cjs.cjs
@@ -1,10 +1,10 @@
 // CJS consumer smoke test. Resolves the package via its `exports.require`
 // condition using a package self-reference, exactly like a downstream
-// `require("@layerv/qurl")` would. Intentionally covers only a minimal
+// `require("@layervai/qurl")` would. Intentionally covers only a minimal
 // happy-path surface — full-surface drift between the two builds is
 // caught by smoke/parity.mjs, and end-to-end client behavior is covered
 // by the vitest suite. Don't pad this out.
-const { QURLClient, QURLError, ValidationError, VERSION } = require("@layerv/qurl");
+const { QURLClient, QURLError, ValidationError, VERSION } = require("@layervai/qurl");
 
 if (typeof QURLClient !== "function") {
   throw new Error("QURLClient is not a constructor");

--- a/smoke/esm.mjs
+++ b/smoke/esm.mjs
@@ -1,7 +1,7 @@
 // ESM consumer smoke test. Mirror of cjs.cjs through `exports.import`
 // via a package self-reference. Same scope as cjs.cjs — minimal happy-
 // path; full-surface drift is caught by smoke/parity.mjs.
-import { QURLClient, QURLError, ValidationError, VERSION } from "@layerv/qurl";
+import { QURLClient, QURLError, ValidationError, VERSION } from "@layervai/qurl";
 
 if (typeof QURLClient !== "function") {
   throw new Error("QURLClient is not a constructor");

--- a/smoke/parity.mjs
+++ b/smoke/parity.mjs
@@ -6,8 +6,8 @@ import { createRequire } from "node:module";
 import assert from "node:assert/strict";
 
 const require = createRequire(import.meta.url);
-const cjs = require("@layerv/qurl");
-const esm = await import("@layerv/qurl");
+const cjs = require("@layervai/qurl");
+const esm = await import("@layervai/qurl");
 
 // Raw Object.keys on both — no filtering. A `default` export landing in
 // only one build is exactly the ESM-only drift this check exists to


### PR DESCRIPTION
## Summary
- rename the npm package and consumer docs from `@layerv/qurl` to `@layervai/qurl`
- switch npm release publishing from `NPM_TOKEN` to npm Trusted Publishing/OIDC
- pin release jobs to npm `11.10.0`, which satisfies npm's trusted-publisher CLI requirements while avoiding the repo's minimum dependency-age fence; future bumps must also satisfy `.npmrc`'s `min-release-age`
- add `workflow_dispatch` with `ref_name` for a corrected manual npm publish, and require that ref to be a full 40-character commit SHA on `main`
- checkout the release/ref before testing and publishing so npm receives the selected artifact, using full git history only for manual dispatch ancestry checks
- serialize only the `publish` job with `concurrency` so npm publishes cannot race, while release-please maintenance and validation jobs can still run
- keep the privileged publish job independent of restored dependency caches by disabling setup-node v6 automatic package-manager caching
- make the arbitrary-ref `test` job read-only so reviewer approval remains the boundary before any publish-capable job runs
- run `npm run smoke:dist` in both `test` and `publish`; publish also explicitly runs build/smoke because `.npmrc` disables lifecycle scripts
- update the package keyword from `layerv` to `layervai` for npm discoverability

## Business relevance
This aligns the TypeScript SDK with the LayerV AI npm namespace used by existing packages such as `@layervai/qurl-mcp`, avoids publishing the SDK under the wrong npm scope, and removes the long-lived npm token dependency from releases. It lets us recover the current npm publish safely after configuring npm's trusted publisher for this repository.

## Validation
- `actionlint .github/workflows/release-please.yml`
- `git diff --check`
- `npm ci`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm test` (339 tests)
- `npm run smoke:dist`

## Npm setup required before publish retry
Configure npm Trusted Publishing for `@layervai/qurl` with:
- Provider: GitHub Actions
- Organization/user: `layervai`
- Repository: `qurl-typescript`
- Workflow filename: `release-please.yml`
- Environment name: `npm-publish`
- Allowed actions: `npm publish`

The GitHub `npm-publish` environment is configured as the manual-publish approval gate:
- required reviewers: `justin-layerv`, `vikramlayerv`, `Kevin-layerV`
- self-review: disabled
- admin bypass: disabled
- deployment branch policy: unrestricted because the workflow itself now requires manual publish refs to be full commit SHAs that are ancestors of `main`

The manual-ref validation intentionally stays inline in both `test` and `publish` rather than moving to a checked-out local script/action, because the checked-out ref is operator-selected.

`gh secret list --repo layervai/qurl-typescript` returned no repo-level `NPM_TOKEN`, so there is no stale repo secret to delete here.

`npm view @layervai/qurl version` currently returns E404. Because npm requires a package to exist before Trusted Publishing / `npm trust` can be configured, the first package bootstrap is tracked in #117. Use a one-time short-lived/granular/manual maintainer path to create the package, then configure Trusted Publishing and use this workflow for subsequent publishes.

The existing `qurl-v0.2.0` tag was cut before the npm scope correction, so do not publish that tag as-is. After this PR merges, #117 is completed, and npm trust is configured, run the `Release Please` workflow manually with `ref_name=<merged commit SHA>` to publish the corrected `@layervai/qurl@0.2.0`, or cut/merge a fresh Release Please version if we want the npm package to correspond to a new release tag.
