### PR TITLE
docs: drop "firewall" terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const result = await client.create({
 });
 console.log(result.qurl_link);
 
-// Resolve a token (opens firewall for your IP)
+// Resolve a token (grants network access for your IP)
 const access = await client.resolve('at_...');
 console.log(`Access granted to ${access.target_url} for ${access.access_grant?.expires_in}s`);
 ```
@@ -67,7 +67,7 @@ console.log(`Access granted to ${access.target_url} for ${access.access_grant?.e
 | `extend(id, input)` | Extend expiration |
 | `update(id, input)` | Update qURL resource properties |
 | `mintLink(id, input?)` | Mint a new access link |
-| `resolve(input)` | Resolve token + open firewall |
+| `resolve(input)` | Resolve token + grant network access |
 | `getQuota()` | Get quota/usage info |
 | `bootstrapAgent(input)` | Bootstrap a qURL Connector agent |
 | `listResources(input?)` / `listAllResources(input?)` / `createResource(input)` / `getResource(id)` | Resource management |

--- a/src/client.ts
+++ b/src/client.ts
@@ -1942,7 +1942,7 @@ export class QURLClient {
   /**
    * Resolve a qURL access token (headless).
    *
-   * Triggers an NHP knock to open firewall access for the caller's IP.
+   * Triggers an NHP knock to grant network access for the caller's IP.
    * Requires `qurl:resolve` scope on the API key.
    *
    * Accepts a plain token string or a `ResolveInput` object.

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,7 +269,7 @@ export interface ResolveInput {
   access_token: string;
 }
 
-/** Details of the firewall access that was granted. */
+/** Details of the network access that was granted. */
 export interface AccessGrant {
   expires_in: number;
   granted_at: string;


### PR DESCRIPTION
## What

Removes "firewall" terminology from the SDK. LayerV is not a firewall company, and qURL's mechanism is better described as **granting network access** via the NHP knock — the wording the qURL MCP server already uses.

Changes (all comment / doc / string — no API, type, or wire changes):

- `README.md` — quickstart comment + the `resolve` method-table row
- `src/client.ts` — `resolve()` JSDoc
- `src/types.ts` — `AccessGrant` doc comment

`AccessGrant` fields (`expires_in`, `granted_at`, …) are unchanged, so nothing on the wire or in the public type surface changes.

Part of a cross-repo qURL conceptual-integrity pass (the integrations repo and the Python SDK get the same treatment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)