### PR TITLE
feat: add resource, session, and token-management methods (+ rename to @layervai/qurl)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 ## Project
 
-TypeScript SDK for the qURL API (`npm install @layerv/qurl`). Extracted from `layervai/qurl-integrations`.
+TypeScript SDK for the qURL API (`npm install @layervai/qurl`). Extracted from `layervai/qurl-integrations`.
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing to `@layerv/qurl`!
+Thanks for your interest in contributing to `@layervai/qurl`!
 
 ## Development Setup
 
@@ -36,7 +36,7 @@ points each condition (`import`, `require`) at its matching build, with
 per-condition `types` so `moduleResolution: Node16` consumers get the
 right `.d.ts`.
 
-`smoke/cjs.cjs` and `smoke/esm.mjs` self-reference `@layerv/qurl` and
+`smoke/cjs.cjs` and `smoke/esm.mjs` self-reference `@layervai/qurl` and
 exercise both entry points end-to-end; `smoke/parity.mjs` additionally
 asserts both builds export the same runtime name set. CI runs all three
 after the build. These are the load-bearing checks that the consumer-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# @layerv/qurl
+# @layervai/qurl
 
-[![npm](https://img.shields.io/npm/v/@layerv/qurl)](https://www.npmjs.com/package/@layerv/qurl)
+[![npm](https://img.shields.io/npm/v/@layervai/qurl)](https://www.npmjs.com/package/@layervai/qurl)
 [![CI](https://github.com/layervai/qurl-typescript/actions/workflows/ci.yml/badge.svg)](https://github.com/layervai/qurl-typescript/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/layervai/qurl-typescript)](LICENSE)
 
@@ -15,15 +15,15 @@ AI agents need to access protected resources — APIs, databases, internal tools
 ## Installation
 
 ```bash
-npm install @layerv/qurl
+npm install @layervai/qurl
 ```
 
-Requires Node.js 18+. Both `import { QURLClient } from '@layerv/qurl'` (ESM) and `const { QURLClient } = require('@layerv/qurl')` (CJS) work.
+Requires Node.js 18+. Both `import { QURLClient } from '@layervai/qurl'` (ESM) and `const { QURLClient } = require('@layervai/qurl')` (CJS) work.
 
 ## Quick Start
 
 ```typescript
-import { QURLClient } from '@layerv/qurl';
+import { QURLClient } from '@layervai/qurl';
 
 const client = new QURLClient({ apiKey: 'lv_live_xxx' });
 
@@ -69,6 +69,14 @@ console.log(`Access granted to ${access.target_url} for ${access.access_grant?.e
 | `mintLink(id, input?)` | Mint a new access link |
 | `resolve(input)` | Resolve token + open firewall |
 | `getQuota()` | Get quota/usage info |
+| `updateResource(id, input)` | Update resource metadata (tags, description, custom domain, preserve_host) |
+| `revokeQurlToken(resourceId, qurlId)` | Revoke a single access token, leaving siblings active |
+| `updateQurlToken(resourceId, qurlId, input)` | Update one access token (expiry, label, access policy, sessions) |
+| `listResourceSessions(resourceId)` | List a resource's active access sessions |
+| `terminateResourceSession(resourceId, sessionId)` | Terminate one active session |
+| `terminateAllResourceSessions(resourceId)` | Terminate all active sessions for a resource |
+
+> The last six target the resource-scoped surface (`/v1/resources/...`) and require an `r_` resource ID.
 
 ### `batchCreate(input)`
 
@@ -110,7 +118,7 @@ import {
   NotFoundError,
   RateLimitError,
   ValidationError,
-} from '@layerv/qurl';
+} from '@layervai/qurl';
 
 try {
   await client.create({ target_url: '' });

--- a/contract/openapi.snapshot.yaml
+++ b/contract/openapi.snapshot.yaml
@@ -31,3 +31,13 @@ paths:
     post: {}
   /v1/quota:
     get: {}
+  /v1/resources/{id}:
+    patch: {}
+  /v1/resources/{id}/qurls/{qurl_id}:
+    patch: {}
+    delete: {}
+  /v1/resources/{id}/sessions:
+    get: {}
+    delete: {}
+  /v1/resources/{id}/sessions/{session_id}:
+    delete: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@layerv/qurl",
+  "name": "@layervai/qurl",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@layerv/qurl",
+      "name": "@layervai/qurl",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@layerv/qurl",
+  "name": "@layervai/qurl",
   "version": "0.1.0",
   "description": "TypeScript SDK for the qURL™ API — secure, time-limited access links. Quantum URL is how you enter the hidden layer of the internet.",
   "type": "module",

--- a/smoke/cjs.cjs
+++ b/smoke/cjs.cjs
@@ -1,10 +1,10 @@
 // CJS consumer smoke test. Resolves the package via its `exports.require`
 // condition using a package self-reference, exactly like a downstream
-// `require("@layerv/qurl")` would. Intentionally covers only a minimal
+// `require("@layervai/qurl")` would. Intentionally covers only a minimal
 // happy-path surface — full-surface drift between the two builds is
 // caught by smoke/parity.mjs, and end-to-end client behavior is covered
 // by the vitest suite. Don't pad this out.
-const { QURLClient, QURLError, ValidationError, VERSION } = require("@layerv/qurl");
+const { QURLClient, QURLError, ValidationError, VERSION } = require("@layervai/qurl");
 
 if (typeof QURLClient !== "function") {
   throw new Error("QURLClient is not a constructor");

--- a/smoke/esm.mjs
+++ b/smoke/esm.mjs
@@ -1,7 +1,7 @@
 // ESM consumer smoke test. Mirror of cjs.cjs through `exports.import`
 // via a package self-reference. Same scope as cjs.cjs — minimal happy-
 // path; full-surface drift is caught by smoke/parity.mjs.
-import { QURLClient, QURLError, ValidationError, VERSION } from "@layerv/qurl";
+import { QURLClient, QURLError, ValidationError, VERSION } from "@layervai/qurl";
 
 if (typeof QURLClient !== "function") {
   throw new Error("QURLClient is not a constructor");

--- a/smoke/parity.mjs
+++ b/smoke/parity.mjs
@@ -6,8 +6,8 @@ import { createRequire } from "node:module";
 import assert from "node:assert/strict";
 
 const require = createRequire(import.meta.url);
-const cjs = require("@layerv/qurl");
-const esm = await import("@layerv/qurl");
+const cjs = require("@layervai/qurl");
+const esm = await import("@layervai/qurl");
 
 // Raw Object.keys on both — no filtering. A `default` export landing in
 // only one build is exactly the ESM-only drift this check exists to

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -5693,4 +5693,238 @@ describe("QURLClient", () => {
       expect(fetch, `status ${c.status}`).toHaveBeenCalledTimes(1);
     }
   });
+
+  // --- Resource-scoped operations: updateResource, token + session mgmt ---
+
+  it("updateResource sends a PATCH to /v1/resources/{id} and maps qurls", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: {
+        data: {
+          resource_id: "r_abc123def45",
+          status: "active",
+          tags: ["prod"],
+          created_at: "2026-03-10T10:00:00Z",
+          qurls: [{ qurl_id: "q_a1b2c3d4e5f", status: "active" }],
+        },
+      },
+    });
+    const client = createClient(fetch);
+    const result = await client.updateResource("r_abc123def45", {
+      tags: ["prod"],
+      description: "updated",
+    });
+
+    expect(result.tags).toEqual(["prod"]);
+    // The wire `qurls` field is renamed to `access_tokens`, like get()/update().
+    expect(result.access_tokens?.[0]?.qurl_id).toBe("q_a1b2c3d4e5f");
+    expect((result as { qurls?: unknown }).qurls).toBeUndefined();
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/resources/r_abc123def45",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ tags: ["prod"], description: "updated" }),
+      }),
+    );
+  });
+
+  it("updateResource preserves custom_domain: '' and preserve_host: false (clear semantics)", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: { data: { resource_id: "r_abc123def45", status: "active", created_at: "t" } },
+    });
+    const client = createClient(fetch);
+    await client.updateResource("r_abc123def45", { custom_domain: "", preserve_host: false });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/resources/r_abc123def45",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ custom_domain: "", preserve_host: false }),
+      }),
+    );
+  });
+
+  it("updateResource rejects a q_ display ID client-side", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: {} } });
+    const client = createClient(fetch);
+    const err = await client
+      .updateResource("q_a1b2c3d4e5f", { description: "x" })
+      .catch((e: unknown) => e as ValidationError);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).code).toBe(ERROR_CODE_CLIENT_VALIDATION);
+    expect((err as ValidationError).detail).toContain("r_ prefix");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("updateResource rejects empty input (no fields)", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: {} } });
+    const client = createClient(fetch);
+    await expect(client.updateResource("r_abc123def45", {})).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("revokeQurlToken sends DELETE to /v1/resources/{id}/qurls/{qurl_id}", async () => {
+    const fetch = mockFetch({ status: 204 });
+    const client = createClient(fetch);
+    await expect(client.revokeQurlToken("r_abc123def45", "q_a1b2c3d4e5f")).resolves.toBeUndefined();
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/resources/r_abc123def45/qurls/q_a1b2c3d4e5f",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("revokeQurlToken rejects a non-r_ resource ID and a non-q_ token ID", async () => {
+    const fetch = mockFetch({ status: 204 });
+    const client = createClient(fetch);
+    await expect(client.revokeQurlToken("q_a1b2c3d4e5f", "q_a1b2c3d4e5f")).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+    await expect(client.revokeQurlToken("r_abc123def45", "r_abc123def45")).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("updateQurlToken sends PATCH to the token endpoint and returns the token", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: { data: { qurl_id: "q_a1b2c3d4e5f", status: "active", label: "renamed" } },
+    });
+    const client = createClient(fetch);
+    const result = await client.updateQurlToken("r_abc123def45", "q_a1b2c3d4e5f", {
+      label: "renamed",
+      max_sessions: 5,
+    });
+
+    expect(result.qurl_id).toBe("q_a1b2c3d4e5f");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/resources/r_abc123def45/qurls/q_a1b2c3d4e5f",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ label: "renamed", max_sessions: 5 }),
+      }),
+    );
+  });
+
+  it("updateQurlToken throws when extend_by and expires_at are both set", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: {} } });
+    const client = createClient(fetch);
+    await expect(
+      client.updateQurlToken("r_abc123def45", "q_a1b2c3d4e5f", {
+        extend_by: "24h",
+        expires_at: "2026-03-10T10:00:00Z",
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("updateQurlToken rejects empty input (no fields)", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: {} } });
+    const client = createClient(fetch);
+    await expect(
+      client.updateQurlToken("r_abc123def45", "q_a1b2c3d4e5f", {}),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("updateQurlToken forwards session_duration: '' (apply parent cap) without rejecting it", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: { data: { qurl_id: "q_a1b2c3d4e5f", status: "active" } },
+    });
+    const client = createClient(fetch);
+    await client.updateQurlToken("r_abc123def45", "q_a1b2c3d4e5f", { session_duration: "" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/resources/r_abc123def45/qurls/q_a1b2c3d4e5f",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ session_duration: "" }),
+      }),
+    );
+  });
+
+  it("listResourceSessions returns the session array", async () => {
+    const fetch = mockFetch({
+      status: 200,
+      body: {
+        data: [{ session_id: "sess_1", qurl_id: "q_a1b2c3d4e5f", src_ip: "203.0.113.5" }],
+        meta: { request_id: "req_1" },
+      },
+    });
+    const client = createClient(fetch);
+    const sessions = await client.listResourceSessions("r_abc123def45");
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].session_id).toBe("sess_1");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/resources/r_abc123def45/sessions",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("listResourceSessions returns [] when there are no active sessions", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: [] } });
+    const client = createClient(fetch);
+    await expect(client.listResourceSessions("r_abc123def45")).resolves.toEqual([]);
+  });
+
+  it("listResourceSessions throws unexpected_response when data is not an array", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: { not: "an array" } } });
+    const client = createClient(fetch);
+    const err = await client
+      .listResourceSessions("r_abc123def45")
+      .catch((e: unknown) => e as ValidationError);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).code).toBe(ERROR_CODE_UNEXPECTED_RESPONSE);
+  });
+
+  it("terminateResourceSession sends DELETE to the per-session endpoint", async () => {
+    const fetch = mockFetch({ status: 204 });
+    const client = createClient(fetch);
+    await expect(
+      client.terminateResourceSession("r_abc123def45", "sess_1"),
+    ).resolves.toBeUndefined();
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/resources/r_abc123def45/sessions/sess_1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("terminateResourceSession rejects an empty session_id", async () => {
+    const fetch = mockFetch({ status: 204 });
+    const client = createClient(fetch);
+    await expect(client.terminateResourceSession("r_abc123def45", "")).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("terminateAllResourceSessions returns the terminated count", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: { terminated: 3 } } });
+    const client = createClient(fetch);
+    await expect(client.terminateAllResourceSessions("r_abc123def45")).resolves.toEqual({
+      terminated: 3,
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.test.layerv.ai/v1/resources/r_abc123def45/sessions",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("terminateAllResourceSessions throws unexpected_response when terminated is missing", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: {} } });
+    const client = createClient(fetch);
+    const err = await client
+      .terminateAllResourceSessions("r_abc123def45")
+      .catch((e: unknown) => e as ValidationError);
+
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).code).toBe(ERROR_CODE_UNEXPECTED_RESPONSE);
+  });
 });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -5767,6 +5767,15 @@ describe("QURLClient", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("updateResource wires in the shared length validator (description > 500 chars)", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: {} } });
+    const client = createClient(fetch);
+    await expect(
+      client.updateResource("r_abc123def45", { description: "x".repeat(501) }),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("revokeQurlToken sends DELETE to /v1/resources/{id}/qurls/{qurl_id}", async () => {
     const fetch = mockFetch({ status: 204 });
     const client = createClient(fetch);
@@ -5827,6 +5836,15 @@ describe("QURLClient", () => {
     const client = createClient(fetch);
     await expect(
       client.updateQurlToken("r_abc123def45", "q_a1b2c3d4e5f", {}),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("updateQurlToken wires in the shared max_sessions range validator (> 1000)", async () => {
+    const fetch = mockFetch({ status: 200, body: { data: {} } });
+    const client = createClient(fetch);
+    await expect(
+      client.updateQurlToken("r_abc123def45", "q_a1b2c3d4e5f", { max_sessions: 1001 }),
     ).rejects.toBeInstanceOf(ValidationError);
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1469,6 +1469,11 @@ export class QURLClient {
         `updateQurlToken: at least one field (${UPDATE_TOKEN_FIELD_KEYS.join(", ")}) must be provided`,
       );
     }
+    // label: the max-length and empty-string checks are complementary, not
+    // redundant — together they enforce 1–500 chars. `""` is rejected (a
+    // likely mistake, not a clear-the-label directive), matching how
+    // create()/mintLink() treat the same field. Contrast `session_duration`
+    // just below, where `""` is a meaningful directive and is allowed through.
     requireMaxLength(normalized.label, "label", MAX_LABEL);
     requireNonEmptyIfPresent(normalized.label, "label");
     requireMaxSessionsInRange(normalized.max_sessions);

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,7 +27,11 @@ import type {
   Quota,
   ResolveInput,
   ResolveOutput,
+  Session,
+  SessionTerminateResult,
   UpdateInput,
+  UpdateQurlTokenInput,
+  UpdateResourceInput,
 } from "./types.js";
 import { VERSION } from "./version.js";
 
@@ -116,6 +120,44 @@ assertExhaustive<
 >(true);
 
 /**
+ * Fields accepted by `updateResource()`. Iterated by the null-stripping
+ * normalization + empty-input guard in {@link QURLClient.updateResource};
+ * the paired `assertExhaustive` witness fails compilation if a new
+ * {@link UpdateResourceInput} field isn't listed here.
+ */
+const UPDATE_RESOURCE_FIELD_KEYS = [
+  "tags",
+  "description",
+  "custom_domain",
+  "preserve_host",
+] as const satisfies readonly (keyof UpdateResourceInput)[];
+
+assertExhaustive<
+  Exclude<keyof UpdateResourceInput, (typeof UPDATE_RESOURCE_FIELD_KEYS)[number]> extends never
+    ? true
+    : never
+>(true);
+
+/**
+ * Fields accepted by `updateQurlToken()`. Same normalization + exhaustiveness
+ * contract as the other `*_FIELD_KEYS` allowlists.
+ */
+const UPDATE_TOKEN_FIELD_KEYS = [
+  "extend_by",
+  "expires_at",
+  "label",
+  "access_policy",
+  "max_sessions",
+  "session_duration",
+] as const satisfies readonly (keyof UpdateQurlTokenInput)[];
+
+assertExhaustive<
+  Exclude<keyof UpdateQurlTokenInput, (typeof UPDATE_TOKEN_FIELD_KEYS)[number]> extends never
+    ? true
+    : never
+>(true);
+
+/**
  * Construct a {@link ValidationError} for a client-side pre-flight check.
  * Uses `status: 0` (matching {@link NetworkError}/{@link TimeoutError}) and
  * `code: "client_validation"` so catch-by-class still works and callers can
@@ -173,6 +215,7 @@ const MAX_TAG_LENGTH = 50;
 // UpdateQurlRequest.tags pattern is specific — enforce it here.
 const TAG_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9 _-]*$/;
 const RESOURCE_ID_PREFIX = "r_";
+const QURL_ID_PREFIX = "q_";
 
 function requireMaxLength(value: string | undefined, field: string, max: number): void {
   if (value === undefined) return;
@@ -225,6 +268,50 @@ function requireNonEmptyId(id: string, method: string): void {
   // The pre-flight error is more actionable than the 404.
   if (typeof id !== "string" || id.trim() === "") {
     throw clientValidationError(`${method}: id is required`);
+  }
+}
+
+/**
+ * Validate that an ID is an `r_` resource ID. The resource-scoped endpoints
+ * (`PATCH /v1/resources/{id}`, `.../sessions`, `.../qurls/{qurl_id}`) only
+ * accept resource IDs — a `q_` display ID or bare prefix collapses the path
+ * or 404s server-side, so catch it before the round-trip. Only the prefix is
+ * echoed in the error (never the raw ID) to keep caller identifiers out of
+ * observability pipelines, matching {@link QURLClient.delete}.
+ */
+function requireResourceId(id: string, method: string): void {
+  if (typeof id !== "string" || id.trim() === "") {
+    throw clientValidationError(`${method}: resource id is required`);
+  }
+  if (!id.startsWith(RESOURCE_ID_PREFIX) || id.length <= RESOURCE_ID_PREFIX.length) {
+    throw clientValidationError(
+      `${method}: requires a resource ID (${RESOURCE_ID_PREFIX} prefix) — ` +
+        `got an ID starting with "${id.slice(0, RESOURCE_ID_PREFIX.length)}"`,
+    );
+  }
+}
+
+/**
+ * Validate that an ID is a `q_` qURL display ID, for the per-token
+ * resource-scoped endpoints. Same prefix-only error-echo posture as
+ * {@link requireResourceId}.
+ */
+function requireQurlId(qurlId: string, method: string): void {
+  if (typeof qurlId !== "string" || qurlId.trim() === "") {
+    throw clientValidationError(`${method}: qurl_id is required`);
+  }
+  if (!qurlId.startsWith(QURL_ID_PREFIX) || qurlId.length <= QURL_ID_PREFIX.length) {
+    throw clientValidationError(
+      `${method}: requires a qURL display ID (${QURL_ID_PREFIX} prefix) — ` +
+        `got an ID starting with "${qurlId.slice(0, QURL_ID_PREFIX.length)}"`,
+    );
+  }
+}
+
+/** Validate a non-empty session ID for the per-session terminate endpoint. */
+function requireNonEmptySessionId(sessionId: string, method: string): void {
+  if (typeof sessionId !== "string" || sessionId.trim() === "") {
+    throw clientValidationError(`${method}: session_id is required`);
   }
 }
 
@@ -1271,6 +1358,188 @@ export class QURLClient {
   /** Get quota and usage information. */
   async getQuota(): Promise<Quota> {
     return this.request<Quota>("GET", "/v1/quota");
+  }
+
+  // --- Resource-scoped operations ---
+  // These target the `/v1/resources/...` surface — resource metadata,
+  // per-token mutations, and sessions — rather than the `/v1/qurls/...`
+  // surface above. All require an `r_` resource ID; a `q_` display ID is
+  // rejected client-side because these paths don't auto-resolve the parent.
+
+  /**
+   * Update resource-level metadata (`tags`, `description`, `custom_domain`,
+   * `preserve_host`) via `PATCH /v1/resources/{id}`.
+   *
+   * Only accepts an `r_` resource ID. Use {@link update} for expiration
+   * changes and for tag/description edits addressed by a `q_` display ID;
+   * `custom_domain` / `preserve_host` live only on this endpoint. At least
+   * one field must be provided. Pass `description: ""`, `tags: []`, or
+   * `custom_domain: ""` to clear those fields.
+   */
+  async updateResource(id: string, input: UpdateResourceInput): Promise<QURL> {
+    requireResourceId(id, "updateResource");
+    if (typeof input !== "object" || input === null) {
+      throw clientValidationError(
+        `updateResource: input must be an object (got ${input === null ? "null" : typeof input})`,
+      );
+    }
+    // Normalize null → omitted (matches update()/mintLink()). Empty strings
+    // are preserved — they are the documented "clear the field" directive
+    // for description / custom_domain, and `preserve_host: false` is a real
+    // value, so the strip key is null/undefined only.
+    const normalized: UpdateResourceInput = {};
+    let hasAnyField = false;
+    for (const key of UPDATE_RESOURCE_FIELD_KEYS) {
+      const value = input[key];
+      if (value !== null && value !== undefined) {
+        (normalized as Record<string, unknown>)[key] = value;
+        hasAnyField = true;
+      }
+    }
+    if (!hasAnyField) {
+      throw clientValidationError(
+        `updateResource: at least one field (${UPDATE_RESOURCE_FIELD_KEYS.join(", ")}) must be provided`,
+      );
+    }
+    requireValidTags(normalized.tags);
+    requireMaxLength(normalized.description, "description", MAX_DESCRIPTION);
+    requireMaxLength(normalized.custom_domain, "custom_domain", MAX_CUSTOM_DOMAIN);
+    const raw = await this.request<QURL & { qurls?: AccessToken[] }>(
+      "PATCH",
+      `/v1/resources/${encodeURIComponent(id)}`,
+      normalized,
+    );
+    return this.mapQurlsField(raw);
+  }
+
+  /**
+   * Revoke a single access token under a resource via
+   * `DELETE /v1/resources/{id}/qurls/{qurl_id}`, leaving sibling tokens on
+   * the same resource active. Use {@link delete} to revoke the whole
+   * resource and every token under it.
+   */
+  async revokeQurlToken(resourceId: string, qurlId: string): Promise<void> {
+    requireResourceId(resourceId, "revokeQurlToken");
+    requireQurlId(qurlId, "revokeQurlToken");
+    await this.rawRequest(
+      "DELETE",
+      `/v1/resources/${encodeURIComponent(resourceId)}/qurls/${encodeURIComponent(qurlId)}`,
+    );
+  }
+
+  /**
+   * Update a single access token (expiration, label, access policy,
+   * `max_sessions`, `session_duration`) via
+   * `PATCH /v1/resources/{id}/qurls/{qurl_id}`.
+   *
+   * `extend_by` and `expires_at` are mutually exclusive; at least one field
+   * must be provided. Returns the updated token summary.
+   */
+  async updateQurlToken(
+    resourceId: string,
+    qurlId: string,
+    input: UpdateQurlTokenInput,
+  ): Promise<AccessToken> {
+    requireResourceId(resourceId, "updateQurlToken");
+    requireQurlId(qurlId, "updateQurlToken");
+    if (typeof input !== "object" || input === null) {
+      throw clientValidationError(
+        `updateQurlToken: input must be an object (got ${input === null ? "null" : typeof input})`,
+      );
+    }
+    const normalized: UpdateQurlTokenInput = {};
+    let hasAnyField = false;
+    for (const key of UPDATE_TOKEN_FIELD_KEYS) {
+      const value = input[key];
+      if (value !== null && value !== undefined) {
+        (normalized as Record<string, unknown>)[key] = value;
+        hasAnyField = true;
+      }
+    }
+    // Timing fields have no clear-semantic; reject empty strings up front.
+    requireNonEmptyIfPresent(normalized.extend_by, "extend_by");
+    requireNonEmptyIfPresent(normalized.expires_at, "expires_at");
+    if (normalized.extend_by !== undefined && normalized.expires_at !== undefined) {
+      throw clientValidationError(
+        "updateQurlToken: `extend_by` and `expires_at` are mutually exclusive — provide at most one",
+      );
+    }
+    if (!hasAnyField) {
+      throw clientValidationError(
+        `updateQurlToken: at least one field (${UPDATE_TOKEN_FIELD_KEYS.join(", ")}) must be provided`,
+      );
+    }
+    requireMaxLength(normalized.label, "label", MAX_LABEL);
+    requireNonEmptyIfPresent(normalized.label, "label");
+    requireMaxSessionsInRange(normalized.max_sessions);
+    requireValidAccessPolicy(normalized.access_policy);
+    // `session_duration: ""` is intentionally NOT rejected here: an empty
+    // string is the documented directive to apply the parent resource's cap
+    // (unlike create/mint, where empty durations are invalid).
+    return this.request<AccessToken>(
+      "PATCH",
+      `/v1/resources/${encodeURIComponent(resourceId)}/qurls/${encodeURIComponent(qurlId)}`,
+      normalized,
+    );
+  }
+
+  /**
+   * List active access sessions for a resource via
+   * `GET /v1/resources/{id}/sessions`. Returns an empty array when there are
+   * no active sessions.
+   */
+  async listResourceSessions(resourceId: string): Promise<Session[]> {
+    requireResourceId(resourceId, "listResourceSessions");
+    const data = await this.request<Session[]>(
+      "GET",
+      `/v1/resources/${encodeURIComponent(resourceId)}/sessions`,
+    );
+    // Defensive: the return type promises `Session[]`. A misbehaving proxy
+    // that drops `data` or sends a non-array would otherwise hand callers a
+    // value that lies about its type.
+    if (!Array.isArray(data)) {
+      throw unexpectedResponseError(
+        "Unexpected response shape from GET /v1/resources/{id}/sessions: `data` was not an array",
+      );
+    }
+    return data;
+  }
+
+  /**
+   * Terminate one active session via
+   * `DELETE /v1/resources/{id}/sessions/{session_id}`. The qURL tokens
+   * themselves are not revoked — only the live session is closed.
+   */
+  async terminateResourceSession(resourceId: string, sessionId: string): Promise<void> {
+    requireResourceId(resourceId, "terminateResourceSession");
+    requireNonEmptySessionId(sessionId, "terminateResourceSession");
+    await this.rawRequest(
+      "DELETE",
+      `/v1/resources/${encodeURIComponent(resourceId)}/sessions/${encodeURIComponent(sessionId)}`,
+    );
+  }
+
+  /**
+   * Terminate ALL active sessions for a resource via
+   * `DELETE /v1/resources/{id}/sessions`. Returns the count terminated. The
+   * qURL tokens themselves are not revoked — only live sessions are closed.
+   */
+  async terminateAllResourceSessions(resourceId: string): Promise<SessionTerminateResult> {
+    requireResourceId(resourceId, "terminateAllResourceSessions");
+    const data = await this.request<{ terminated?: unknown }>(
+      "DELETE",
+      `/v1/resources/${encodeURIComponent(resourceId)}/sessions`,
+    );
+    // Shape guard: the count drives caller-facing messaging, so a missing or
+    // non-numeric `terminated` is a server-contract violation worth failing
+    // loudly rather than coercing to NaN/undefined downstream.
+    if (!data || typeof data.terminated !== "number" || !Number.isFinite(data.terminated)) {
+      throw unexpectedResponseError(
+        "Unexpected response shape from DELETE /v1/resources/{id}/sessions: " +
+          "`data.terminated` was not a number",
+      );
+    }
+    return { terminated: data.terminated };
   }
 
   // --- Internal HTTP plumbing ---

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -256,6 +256,51 @@ const METHOD_CASES: MethodCase[] = [
     mockBody: { data: { plan: "free" } },
     invoke: (c) => c.getQuota(),
   },
+  {
+    method: "updateResource",
+    verb: "PATCH",
+    template: "/v1/resources/{id}",
+    mockBody: { data: { resource_id: "r_x" } },
+    invoke: (c) => c.updateResource("r_x", { description: "d" }),
+  },
+  {
+    method: "revokeQurlToken",
+    verb: "DELETE",
+    template: "/v1/resources/{id}/qurls/{qurl_id}",
+    // Real API returns 204 No Content; match it so the 204-branch runs.
+    mockBody: undefined,
+    mockStatus: 204,
+    invoke: (c) => c.revokeQurlToken("r_x", "q_x"),
+  },
+  {
+    method: "updateQurlToken",
+    verb: "PATCH",
+    template: "/v1/resources/{id}/qurls/{qurl_id}",
+    mockBody: { data: { qurl_id: "q_x", status: "active" } },
+    invoke: (c) => c.updateQurlToken("r_x", "q_x", { label: "L" }),
+  },
+  {
+    method: "listResourceSessions",
+    verb: "GET",
+    template: "/v1/resources/{id}/sessions",
+    mockBody: { data: [] },
+    invoke: (c) => c.listResourceSessions("r_x"),
+  },
+  {
+    method: "terminateAllResourceSessions",
+    verb: "DELETE",
+    template: "/v1/resources/{id}/sessions",
+    mockBody: { data: { terminated: 0 } },
+    invoke: (c) => c.terminateAllResourceSessions("r_x"),
+  },
+  {
+    method: "terminateResourceSession",
+    verb: "DELETE",
+    template: "/v1/resources/{id}/sessions/{session_id}",
+    mockBody: undefined,
+    mockStatus: 204,
+    invoke: (c) => c.terminateResourceSession("r_x", "sess_1"),
+  },
 ];
 
 // `toJSON` is a diagnostic helper (used by console.log/JSON.stringify),

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,5 +40,9 @@ export type {
   Quota,
   ResolveInput,
   ResolveOutput,
+  Session,
+  SessionTerminateResult,
   UpdateInput,
+  UpdateQurlTokenInput,
+  UpdateResourceInput,
 } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,8 +58,21 @@ export interface AccessToken {
  */
 export interface QURL {
   resource_id: string;
-  target_url: string;
-  status: "active" | "revoked";
+  /**
+   * The protected URL. Optional: the API omits it (field absent, not
+   * `null`) when not applicable to the resource — most notably on
+   * connector-owned rows, whose user-content fields are redacted from
+   * management reads. Matches `ResourceData.target_url` in the OpenAPI spec.
+   */
+  target_url?: string;
+  /**
+   * Resource lifecycle status. The OpenAPI `ResourceData.status` enum lists
+   * only `active`/`revoked`, but reads surface `expired` as a documented
+   * lifecycle value once a resource passes `expires_at` without an explicit
+   * revoke. Treat the set as open — tolerate values you don't recognize
+   * rather than asserting exhaustiveness.
+   */
+  status: "active" | "revoked" | "expired";
   description?: string;
   tags?: string[];
   /**
@@ -75,6 +88,18 @@ export interface QURL {
   custom_domain?: string | null;
   qurl_site?: string;
   qurl_count?: number;
+  /**
+   * Per-owner immutable identity supplied at create time (`slug` on
+   * `POST /v1/resources`). Read-only and absent on resources created
+   * without one. Distinct from a mutable alias.
+   */
+  slug?: string;
+  /**
+   * When `true`, the original `Host` header is preserved when proxying
+   * via the custom domain. Only meaningful when `custom_domain` is set;
+   * defaults to `false` server-side.
+   */
+  preserve_host?: boolean;
   access_tokens?: AccessToken[];
   created_at: string;
   expires_at?: string;
@@ -108,6 +133,15 @@ export interface CreateOutput {
   qurl_site: string;
   expires_at?: string;
   label?: string;
+  /**
+   * Customer's bare branded hostname for anchor-text display alongside
+   * `qurl_link` (render as `<a href="{qurl_link}">{branded_domain}</a>`).
+   * Present only when the resource has a usable `custom_domain`; omitted
+   * otherwise.
+   */
+  branded_domain?: string;
+  /** Resource type — echoes the `type` from the create request. */
+  type?: string;
 }
 
 /** Input for listing qURLs. */
@@ -206,6 +240,64 @@ export interface UpdateInput {
 }
 
 /**
+ * Input for updating resource-level metadata via `PATCH /v1/resources/{id}`.
+ *
+ * Distinct from {@link UpdateInput}, which targets `PATCH /v1/qurls/{id}` and
+ * carries expiration fields. This endpoint owns the resource-only fields —
+ * `custom_domain` and `preserve_host` — that have no equivalent on the qURL
+ * path. `tags`/`description` are accepted on both; route them here when you
+ * also need to change a resource-only field in the same call.
+ *
+ * At least one field must be provided. Pass `description: ""`, `tags: []`, or
+ * `custom_domain: ""` to clear those fields.
+ */
+export interface UpdateResourceInput {
+  /** Replace all tags on this resource. Pass an empty array to clear all tags. */
+  tags?: string[];
+  /** Resource-level description. Pass an empty string to clear it. */
+  description?: string;
+  /**
+   * The custom hostname this resource is reachable under. Pass an empty
+   * string to clear (unbind) the existing custom domain. Max 253 chars;
+   * the host must be registered/active/owned by the caller.
+   */
+  custom_domain?: string;
+  /**
+   * Whether to preserve the original `Host` header when proxying via the
+   * custom domain. Only meaningful when `custom_domain` is set.
+   */
+  preserve_host?: boolean;
+}
+
+/**
+ * Input for updating a single access token via
+ * `PATCH /v1/resources/{id}/qurls/{qurl_id}`.
+ *
+ * Operates on one token under a resource without touching sibling tokens or
+ * resource-level metadata. `extend_by` and `expires_at` are mutually
+ * exclusive; at least one field must be provided. Unlike {@link UpdateInput},
+ * `access_policy` *can* be changed here — token policy is mutable per-token
+ * even though it's immutable at the resource level.
+ */
+export interface UpdateQurlTokenInput {
+  /** Relative duration to extend this token by (e.g., `"24h"`). Mutually exclusive with `expires_at`. */
+  extend_by?: string;
+  /** Absolute RFC 3339 expiration timestamp. Mutually exclusive with `extend_by`. */
+  expires_at?: string;
+  /** Human-readable label for this token. Max 500 chars. */
+  label?: string;
+  /** Replace the access policy for this token. */
+  access_policy?: AccessPolicy;
+  /** Maximum concurrent sessions. `0` = unlimited (default); max `1000`. */
+  max_sessions?: number;
+  /**
+   * How long access lasts after clicking (e.g., `"1h"`). An empty string
+   * applies the parent resource's cap when one is set.
+   */
+  session_duration?: string;
+}
+
+/**
  * Input for minting an access link.
  *
  * `expires_in` and `expires_at` are mutually exclusive — provide at most one.
@@ -237,8 +329,22 @@ export interface MintInput {
 
 /** Response from minting an access link. */
 export interface MintOutput {
+  /**
+   * The minted qURL's primary key (`q_` prefix), same identifier as
+   * {@link CreateOutput.qurl_id}. `qurl.accessed` webhook events are keyed
+   * on this ID — capture it at mint time to correlate access events back
+   * to the recipient/context you minted for.
+   */
+  qurl_id: string;
   qurl_link: string;
   expires_at?: string;
+  /**
+   * Customer's bare branded hostname for anchor-text display alongside
+   * `qurl_link`. See {@link CreateOutput.branded_domain}.
+   */
+  branded_domain?: string;
+  /** Resource type — echoes the type of the underlying resource. */
+  type?: string;
 }
 
 /** Input for headless qURL resolution. */
@@ -304,6 +410,25 @@ export interface Quota {
     active_qurls_percent?: number | null;
     total_accesses?: number;
   };
+}
+
+/** An active access session against a resource. */
+export interface Session {
+  /** Unique session identifier. */
+  session_id: string;
+  /** qURL display ID (`q_` prefix) that created this session. */
+  qurl_id?: string;
+  /** Client IP that created the session. */
+  src_ip?: string;
+  user_agent?: string;
+  created_at?: string;
+  last_seen_at?: string;
+}
+
+/** Result of terminating sessions for a resource. */
+export interface SessionTerminateResult {
+  /** Number of sessions terminated. */
+  terminated: number;
 }
 
 /** Input for batch creating qURLs. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,11 +66,11 @@ export interface QURL {
    */
   target_url?: string;
   /**
-   * Resource lifecycle status. The OpenAPI `ResourceData.status` enum lists
-   * only `active`/`revoked`, but reads surface `expired` as a documented
-   * lifecycle value once a resource passes `expires_at` without an explicit
-   * revoke. Treat the set as open — tolerate values you don't recognize
-   * rather than asserting exhaustiveness.
+   * Resource lifecycle status. The OpenAPI enum lists only `active`/`revoked`,
+   * but reads compute `expired` at response time for resources past their
+   * `expires_at` that were never explicitly revoked (per the `QurlData.status`
+   * description), so it is included here. Closed union, mirroring
+   * {@link AccessToken.status}.
    */
   status: "active" | "revoked" | "expired";
   description?: string;
@@ -250,6 +250,12 @@ export interface UpdateInput {
  *
  * At least one field must be provided. Pass `description: ""`, `tags: []`, or
  * `custom_domain: ""` to clear those fields.
+ *
+ * **`alias` is intentionally not handled here.** The endpoint accepts it, but
+ * its RFC 7396 tri-valued semantics (`null` clears) don't fit this SDK's
+ * shared null-stripping normalization, so alias set/clear is tracked
+ * separately — see
+ * {@link https://github.com/layervai/qurl-typescript/issues/125 | #125}.
  */
 export interface UpdateResourceInput {
   /** Replace all tags on this resource. Pass an empty array to clear all tags. */


### PR DESCRIPTION
## Why

The qURL MCP server (`layervai/qurl-mcp`) currently ships its own hand-rolled HTTP client because this SDK only covered the core `/v1/qurls`, `/v1/resolve`, and `/v1/quota` surface. To let the MCP switch to this SDK **without dropping features**, the SDK needs the resource-scoped endpoints and a few read-shape fields it was under-reporting.

This is **PR #1 of 2**. Once this is merged and published as `@layervai/qurl`, a follow-up PR in `qurl-mcp` deletes its `src/client.ts` and consumes this package.

## What

### New methods (resource-scoped surface)
| Method | Endpoint |
|--------|----------|
| `updateResource(id, input)` | `PATCH /v1/resources/{id}` |
| `revokeQurlToken(resourceId, qurlId)` | `DELETE /v1/resources/{id}/qurls/{qurl_id}` |
| `updateQurlToken(resourceId, qurlId, input)` | `PATCH /v1/resources/{id}/qurls/{qurl_id}` |
| `listResourceSessions(resourceId)` | `GET /v1/resources/{id}/sessions` |
| `terminateResourceSession(resourceId, sessionId)` | `DELETE /v1/resources/{id}/sessions/{session_id}` |
| `terminateAllResourceSessions(resourceId)` | `DELETE /v1/resources/{id}/sessions` |

All require an `r_` resource ID (rejected client-side otherwise), follow the existing validation idioms (null-stripping normalization, empty-input + `extend_by`/`expires_at` XOR guards, defensive response shape guards), and are wired into `contract/openapi.snapshot.yaml` + `METHOD_CASES`.

### Enriched read shapes (no feature loss for the MCP)
- `MintOutput` → adds `qurl_id` (required), `branded_domain`, `type`
- `CreateOutput` → adds `branded_domain`, `type`
- `QURL` → adds `slug`, `preserve_host`, makes `target_url` optional (connector-owned rows redact it), and widens `status` to include the documented `expired` lifecycle value

### New exported types
`UpdateResourceInput`, `UpdateQurlTokenInput`, `Session`, `SessionTerminateResult`

### Package rename
`@layerv/qurl` → `@layervai/qurl` (matches the `@layervai` npm scope used by `@layervai/qurl-mcp`; the package was never published under the old name, so this is clean). Updated: `package.json`, lockfile, README, CLAUDE.md, CONTRIBUTING.md, and the self-referencing smoke tests.

## Verification
- `npm run build` ✅
- `npm run lint` ✅
- `npm test` ✅ (245 tests — includes new contract cases + behavioral tests + completeness/coverage guards)
- `npm run smoke:dist` ✅ (CJS/ESM/parity under the new package name)
- `npm run format:check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)