### PR TITLE
fix(ci): drop registry-url so trusted publishing works for @layervai/qurl

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -124,7 +124,17 @@ jobs:
           # setup-node v6 auto-caches package managers by default; keep the
           # privileged publish job independent of restored dependency caches.
           package-manager-cache: false
-          registry-url: "https://registry.npmjs.org"
+          # Intentionally NO `registry-url`. With it, setup-node writes an
+          # .npmrc containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
+          # and exports a *placeholder* NODE_AUTH_TOKEN (XXXXX-XXXXX-XXXXX-XXXXX)
+          # when no real token is provided. npm then authenticates the publish
+          # with that bogus token and never falls back to OIDC trusted
+          # publishing — first publish fails with `E404 ... not found or you do
+          # not have permission`. Omitting it leaves no token auth configured,
+          # so `npm publish` (npm 11.5.1+) uses the trusted publisher (the
+          # id-token: write permission below) to mint a short-lived publish
+          # token. The default registry is already registry.npmjs.org and
+          # `publishConfig.access: public` in package.json handles scope access.
       - run: npm install -g npm@${{ env.NPM_VERSION }}
       - run: npm ci
       # .npmrc disables lifecycle scripts, so build and smoke explicitly here.


### PR DESCRIPTION
## Problem

`@layervai/qurl` has never published to npm. The 0.2.0 release publish failed, and a manual `workflow_dispatch` publish (run 27317922844) failed too — even after a trusted publisher was configured on npmjs.com — with:

```
npm error 404 - PUT https://registry.npmjs.org/@layervai%2fqurl
'@layervai/qurl@0.2.0' could not be found or you do not have permission to access it.
```

## Root cause

The publish job's `actions/setup-node` step sets `registry-url`. The repo uses **tokenless trusted publishing** (no `NPM_TOKEN` secret anywhere — repo, environment, or org). With `registry-url` set and no token provided, setup-node:
1. writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, and
2. exports a **placeholder** `NODE_AUTH_TOKEN` = `XXXXX-XXXXX-XXXXX-XXXXX`.

`npm publish` then authenticates with that bogus placeholder token and **never falls back to OIDC trusted publishing** → E404. The run log confirms it: the provenance statement was signed via OIDC successfully, but the registry **PUT** used the placeholder token.

## Fix

Remove `registry-url` from the publish `setup-node` step. With no token auth configured, `npm publish` (npm 11.5.1+) uses the trusted publisher via the job's existing `id-token: write` to mint a short-lived publish token. The default registry is already `registry.npmjs.org`, and `publishConfig.access: public` in `package.json` handles scope access.

No change to the environment / required-reviewer / ref-validation guards.

## Verification plan

After merge, re-run the manual publish (`workflow_dispatch` with `ref_name` = a main SHA). Expect `npm publish` to succeed and `@layervai/qurl@0.2.0` to appear on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)