### PR TITLE
fix(ci): make OIDC trusted publishing engage (restore registry-url + strip placeholder token)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -124,17 +124,16 @@ jobs:
           # setup-node v6 auto-caches package managers by default; keep the
           # privileged publish job independent of restored dependency caches.
           package-manager-cache: false
-          # Intentionally NO `registry-url`. With it, setup-node writes an
-          # .npmrc containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
-          # and exports a *placeholder* NODE_AUTH_TOKEN (XXXXX-XXXXX-XXXXX-XXXXX)
-          # when no real token is provided. npm then authenticates the publish
-          # with that bogus token and never falls back to OIDC trusted
-          # publishing — first publish fails with `E404 ... not found or you do
-          # not have permission`. Omitting it leaves no token auth configured,
-          # so `npm publish` (npm 11.5.1+) uses the trusted publisher (the
-          # id-token: write permission below) to mint a short-lived publish
-          # token. The default registry is already registry.npmjs.org and
-          # `publishConfig.access: public` in package.json handles scope access.
+          # `registry-url` is REQUIRED for OIDC trusted publishing — it's in
+          # npm's canonical example, and without it `npm publish` never
+          # attempts the OIDC exchange and fails ENEEDAUTH. setup-node also
+          # exports a placeholder NODE_AUTH_TOKEN here, but that's fine: once
+          # the npm-side trusted-publisher config matches the workflow's OIDC
+          # claims, npm's OIDC auth takes precedence over the placeholder. The
+          # match must cover repo `layervai/qurl-typescript`, workflow file
+          # `release-please.yml`, AND the `npm-publish` environment used below
+          # (an env-scoped job changes the OIDC `sub` claim).
+          registry-url: "https://registry.npmjs.org"
       - run: npm install -g npm@${{ env.NPM_VERSION }}
       - run: npm ci
       # .npmrc disables lifecycle scripts, so build and smoke explicitly here.


### PR DESCRIPTION
## Context

Chasing the `@layervai/qurl` first-publish failure. #127 removed `registry-url` on the theory that setup-node's placeholder `NODE_AUTH_TOKEN` was shadowing OIDC. That was a **red herring** — after merging it, the manual publish (run 27318436637) failed with **`ENEEDAUTH` (need auth / requires you to be logged in)**, because without `registry-url` npm never attempts the OIDC exchange at all.

## Fix

Restore `registry-url: "https://registry.npmjs.org"` on the publish `setup-node` step — it's in [npm's canonical trusted-publishing workflow](https://docs.npmjs.com/trusted-publishers). Per the docs, npm's OIDC auth takes precedence over the placeholder token **once the trusted-publisher config matches**, so the placeholder is harmless.

## The actual root cause (npm-side, not code)

OIDC isn't engaging because the npm trusted-publisher config doesn't match the workflow's OIDC claims. Verified the workflow side is correct: Node v22.22.3 (≥22.14.0), npm 11.10.0 (≥11.5.1), `id-token: write` present, `repository.url` matches. The publish job runs in **`environment: npm-publish`**, which makes the OIDC `sub` claim environment-scoped — so the npm trusted publisher must specify:

- Organization: **layervai** · Repository: **qurl-typescript**
- Workflow filename: **release-please.yml** (exact, case-sensitive)
- **Environment: npm-publish** ← most likely the missing field

Once that's set, re-dispatch the manual publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)