### PR TITLE
build(deps): bump brace-expansion 5.0.5 -> 5.0.6 via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -998,9 +998,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

`npm audit fix` bumped the transitive dev dependency `brace-expansion` from `5.0.5` to `5.0.6`. This is the only change.

- Dev-only (`"dev": true`) transitive dependency — it does **not** ship in the published `@layervai/qurl` package, so consumers are unaffected.
- Using `build(deps):` (matching prior dependency bumps like #111) so Release Please does **not** cut a release for this dev-only change. If you'd prefer a patch release, retitle to `fix(deps):`.

## Test plan

- [x] Diff is limited to the `brace-expansion` version/resolved/integrity fields in `package-lock.json`
- [x] Commit is GPG-signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)