### PR TITLE
feat: support target_path on createQurlForResource

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1181,6 +1181,19 @@ describe("QURLClient", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("createQurlForResource rejects a non-string target_path before making requests", async () => {
+    const fetch = mockFetch({ status: 201, body: { data: {} } });
+    const client = createClient(fetch);
+
+    const error = await client
+      .createQurlForResource("r_x", { target_path: 42 } as never)
+      .catch((e: unknown) => e as ValidationError);
+
+    expect(error).toBeInstanceOf(ValidationError);
+    expect(error.detail).toContain("target_path: must be a string");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("updateResourceQurl validates shared qURL token options client-side", async () => {
     const fetch = mockFetch({ status: 200, body: { data: {} } });
     const client = createClient(fetch);

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1169,15 +1169,18 @@ describe("QURLClient", () => {
   it("createQurlForResource rejects an overlong target_path before making requests", async () => {
     const fetch = mockFetch({ status: 201, body: { data: {} } });
     const client = createClient(fetch);
-    // Leading "/" makes this 2049 chars, one over the 2048-char service cap.
-    const overlongTargetPath = `/${"x".repeat(2048)}`;
+    const targetPathMaxLength = 2048;
+    // Leading "/" makes this one character over the service cap.
+    const overlongTargetPath = `/${"x".repeat(targetPathMaxLength)}`;
 
     const error = await client
       .createQurlForResource("r_x", { target_path: overlongTargetPath })
       .catch((e: unknown) => e as ValidationError);
 
     expect(error).toBeInstanceOf(ValidationError);
-    expect(error.detail).toContain("target_path: must be 2048 characters or fewer");
+    expect(error.detail).toContain(
+      `target_path: must be ${targetPathMaxLength} characters or fewer`,
+    );
     expect(fetch).not.toHaveBeenCalled();
   });
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -20,6 +20,7 @@ import type { BatchCreateInput, CreateInput, ExtendInput, MintInput } from "./ty
 import { mockFetch, mockFetches, createClient } from "./__tests__/test-helpers.js";
 
 const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const TARGET_PATH_MAX_LENGTH = 2048;
 
 function callHeaders(
   fetch: typeof globalThis.fetch | ReturnType<typeof vi.fn>,
@@ -1166,12 +1167,27 @@ describe("QURLClient", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("createQurlForResource accepts target_path at the service length boundary", async () => {
+    const fetch = mockFetch({
+      status: 201,
+      body: { data: { qurl_link: "https://qurl.link/#at_x" } },
+    });
+    const client = createClient(fetch);
+    // The service cap applies to the complete target_path string, including
+    // the leading slash.
+    const maxLengthTargetPath = `/${"x".repeat(TARGET_PATH_MAX_LENGTH - 1)}`;
+
+    await client.createQurlForResource("r_x", { target_path: maxLengthTargetPath });
+
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string) as unknown;
+    expect(body).toEqual({ target_path: maxLengthTargetPath });
+  });
+
   it("createQurlForResource rejects an overlong target_path before making requests", async () => {
     const fetch = mockFetch({ status: 201, body: { data: {} } });
     const client = createClient(fetch);
-    const targetPathMaxLength = 2048;
-    // Leading "/" makes this one character over the service cap.
-    const overlongTargetPath = `/${"x".repeat(targetPathMaxLength)}`;
+    // Leading "/" makes this one character over the complete-string service cap.
+    const overlongTargetPath = `/${"x".repeat(TARGET_PATH_MAX_LENGTH)}`;
 
     const error = await client
       .createQurlForResource("r_x", { target_path: overlongTargetPath })
@@ -1179,7 +1195,7 @@ describe("QURLClient", () => {
 
     expect(error).toBeInstanceOf(ValidationError);
     expect(error.detail).toContain(
-      `target_path: must be ${targetPathMaxLength} characters or fewer`,
+      `target_path: must be ${TARGET_PATH_MAX_LENGTH} characters or fewer`,
     );
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1166,6 +1166,19 @@ describe("QURLClient", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("createQurlForResource rejects an overlong target_path before making requests", async () => {
+    const fetch = mockFetch({ status: 201, body: { data: {} } });
+    const client = createClient(fetch);
+
+    const error = await client
+      .createQurlForResource("r_x", { target_path: `/${"x".repeat(2048)}` })
+      .catch((e: unknown) => e as ValidationError);
+
+    expect(error).toBeInstanceOf(ValidationError);
+    expect(error.detail).toContain("target_path: must be 2048 characters or fewer");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("updateResourceQurl validates shared qURL token options client-side", async () => {
     const fetch = mockFetch({ status: 200, body: { data: {} } });
     const client = createClient(fetch);

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1169,9 +1169,11 @@ describe("QURLClient", () => {
   it("createQurlForResource rejects an overlong target_path before making requests", async () => {
     const fetch = mockFetch({ status: 201, body: { data: {} } });
     const client = createClient(fetch);
+    // Leading "/" makes this 2049 chars, one over the 2048-char service cap.
+    const overlongTargetPath = `/${"x".repeat(2048)}`;
 
     const error = await client
-      .createQurlForResource("r_x", { target_path: `/${"x".repeat(2048)}` })
+      .createQurlForResource("r_x", { target_path: overlongTargetPath })
       .catch((e: unknown) => e as ValidationError);
 
     expect(error).toBeInstanceOf(ValidationError);

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1135,6 +1135,37 @@ describe("QURLClient", () => {
     expect(body).toEqual({ expires_in: "1h" });
   });
 
+  it("createQurlForResource forwards target_path in the request body", async () => {
+    // `target_path` is a server-validated resource-qURL field (sets the path a
+    // tunnel qURL resolves to, e.g. for the Discord bot's detect tunnel). It
+    // must survive the field allowlist + normalization and reach the wire.
+    const fetch = mockFetch({
+      status: 201,
+      body: { data: { qurl_link: "https://qurl.link/#at_x" } },
+    });
+    const client = createClient(fetch);
+
+    await client.createQurlForResource("r_x", { target_path: "/api/detect" });
+
+    const call = vi.mocked(fetch).mock.calls[0];
+    expect(new URL(call[0] as string).pathname).toBe("/v1/resources/r_x/qurls");
+    const body = JSON.parse(call[1]?.body as string) as unknown;
+    expect(body).toEqual({ target_path: "/api/detect" });
+  });
+
+  it("createQurlForResource rejects an empty target_path before making requests", async () => {
+    const fetch = mockFetch({ status: 201, body: { data: {} } });
+    const client = createClient(fetch);
+
+    const error = await client
+      .createQurlForResource("r_x", { target_path: "" })
+      .catch((e: unknown) => e as ValidationError);
+
+    expect(error).toBeInstanceOf(ValidationError);
+    expect(error.detail).toContain("target_path: must not be an empty string");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("updateResourceQurl validates shared qURL token options client-side", async () => {
     const fetch = mockFetch({ status: 200, body: { data: {} } });
     const client = createClient(fetch);

--- a/src/client.ts
+++ b/src/client.ts
@@ -631,6 +631,7 @@ const MAX_MAX_SESSIONS = 1000;
 const MAX_API_KEY_NAME = 100;
 const MAX_ALIAS = 64;
 const MAX_SLUG = 64;
+const MAX_TARGET_PATH = 2048;
 const MAX_TAGS = 10;
 const MAX_TAG_LENGTH = 50;
 const MAX_AUTO_PAGINATION_PAGES = 10_000;
@@ -999,11 +1000,11 @@ function validateQurlTokenOptions(input: CreateQurlForResourceInput | undefined)
   requireNonEmptyIfPresent(input.label, "label");
   requireNonEmptyIfPresent(input.expires_in, "expires_in");
   requireNonEmptyIfPresent(input.session_duration, "session_duration");
-  // Empty-string guard only, mirroring the other optional server-grammar
-  // string fields above. The leading-slash rule and path grammar are
-  // server-authoritative (`invalid_target_path`); a client-side regex would
-  // just create a drift surface, so it's intentionally omitted.
   requireNonEmptyIfPresent(input.target_path, "target_path");
+  requireMaxLength(input.target_path, "target_path", MAX_TARGET_PATH);
+  // Host-safety grammar (single leading slash, no scheme/host/backslash/etc.)
+  // and the tunnel-only gate remain server-authoritative (`invalid_target_path`);
+  // a client-side regex would create a drift surface.
   requireBooleanIfPresent(input.one_time_use, "one_time_use");
   requireMaxSessionsInRange(input.max_sessions);
   requireValidAccessPolicy(input.access_policy);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1000,12 +1000,12 @@ function validateQurlTokenOptions(input: CreateQurlForResourceInput | undefined)
   requireNonEmptyIfPresent(input.label, "label");
   requireNonEmptyIfPresent(input.expires_in, "expires_in");
   requireNonEmptyIfPresent(input.session_duration, "session_duration");
-  requireNonEmptyIfPresent(input.target_path, "target_path");
-  requireMaxLength(input.target_path, "target_path", MAX_TARGET_PATH);
   // Mirror the service-documented size cap, but keep host-safety grammar
   // (single leading slash, no scheme/host/backslash/etc.) and the tunnel-only
   // gate server-authoritative (`invalid_target_path`); a client-side regex
   // would create a drift surface.
+  requireMaxLength(input.target_path, "target_path", MAX_TARGET_PATH);
+  requireNonEmptyIfPresent(input.target_path, "target_path");
   requireBooleanIfPresent(input.one_time_use, "one_time_use");
   requireMaxSessionsInRange(input.max_sessions);
   requireValidAccessPolicy(input.access_policy);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1003,7 +1003,8 @@ function validateQurlTokenOptions(input: CreateQurlForResourceInput | undefined)
   // Mirror the service-documented size cap, but keep host-safety grammar
   // (single leading slash, no scheme/host/backslash/etc.) and the tunnel-only
   // gate server-authoritative (`invalid_target_path`); a client-side regex
-  // would create a drift surface.
+  // would create a drift surface. Keep max-before-empty consistent with label;
+  // empty strings pass the length check and are rejected by the next guard.
   requireMaxLength(input.target_path, "target_path", MAX_TARGET_PATH);
   requireNonEmptyIfPresent(input.target_path, "target_path");
   requireBooleanIfPresent(input.one_time_use, "one_time_use");

--- a/src/client.ts
+++ b/src/client.ts
@@ -257,6 +257,7 @@ const CREATE_QURL_FOR_RESOURCE_FIELD_KEYS = [
   "session_duration",
   "label",
   "access_policy",
+  "target_path",
 ] as const satisfies readonly (keyof CreateQurlForResourceInput)[];
 
 assertExhaustive<
@@ -998,6 +999,11 @@ function validateQurlTokenOptions(input: CreateQurlForResourceInput | undefined)
   requireNonEmptyIfPresent(input.label, "label");
   requireNonEmptyIfPresent(input.expires_in, "expires_in");
   requireNonEmptyIfPresent(input.session_duration, "session_duration");
+  // Empty-string guard only, mirroring the other optional server-grammar
+  // string fields above. The leading-slash rule and path grammar are
+  // server-authoritative (`invalid_target_path`); a client-side regex would
+  // just create a drift surface, so it's intentionally omitted.
+  requireNonEmptyIfPresent(input.target_path, "target_path");
   requireBooleanIfPresent(input.one_time_use, "one_time_use");
   requireMaxSessionsInRange(input.max_sessions);
   requireValidAccessPolicy(input.access_policy);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1002,9 +1002,10 @@ function validateQurlTokenOptions(input: CreateQurlForResourceInput | undefined)
   requireNonEmptyIfPresent(input.session_duration, "session_duration");
   requireNonEmptyIfPresent(input.target_path, "target_path");
   requireMaxLength(input.target_path, "target_path", MAX_TARGET_PATH);
-  // Host-safety grammar (single leading slash, no scheme/host/backslash/etc.)
-  // and the tunnel-only gate remain server-authoritative (`invalid_target_path`);
-  // a client-side regex would create a drift surface.
+  // Mirror the service-documented size cap, but keep host-safety grammar
+  // (single leading slash, no scheme/host/backslash/etc.) and the tunnel-only
+  // gate server-authoritative (`invalid_target_path`); a client-side regex
+  // would create a drift surface.
   requireBooleanIfPresent(input.one_time_use, "one_time_use");
   requireMaxSessionsInRange(input.max_sessions);
   requireValidAccessPolicy(input.access_policy);

--- a/src/types.ts
+++ b/src/types.ts
@@ -418,7 +418,13 @@ export interface ResourceListOutput extends PaginatedOutput {
 }
 
 /** Input for minting a qURL against an existing resource. */
-export type CreateQurlForResourceInput = Omit<CreateInput, "target_url" | "custom_domain" | "type">;
+export type CreateQurlForResourceInput = Omit<
+  CreateInput,
+  "target_url" | "custom_domain" | "type"
+> & {
+  /** Path appended to the resource's target when this qURL resolves (e.g. "/api/detect"); server-validated, must start with "/". */
+  target_path?: string;
+};
 
 type UpdateResourceQurlBaseInput = {
   label?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -422,7 +422,12 @@ export type CreateQurlForResourceInput = Omit<
   CreateInput,
   "target_url" | "custom_domain" | "type"
 > & {
-  /** Path appended to the resource's target when this qURL resolves (e.g. "/api/detect"); server-validated, must start with "/". */
+  /**
+   * Path appended to the resource's target when this qURL resolves (e.g. "/api/detect").
+   *
+   * Server-validated; invalid paths such as those missing a leading "/" are
+   * rejected by the API.
+   */
   target_path?: string;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -423,10 +423,10 @@ export type CreateQurlForResourceInput = Omit<
   "target_url" | "custom_domain" | "type"
 > & {
   /**
-   * Path appended to the resource's target when this qURL resolves (e.g. "/api/detect").
+   * Path this resource qURL resolves to (e.g. "/api/detect").
    *
-   * Server-validated; invalid paths such as those missing a leading "/" are
-   * rejected by the API.
+   * Creation-only and valid only for tunnel resources. The API rejects invalid
+   * paths, including paths missing a leading "/" or exceeding 2048 characters.
    */
   target_path?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -425,9 +425,9 @@ export type CreateQurlForResourceInput = Omit<
   /**
    * Path this resource qURL resolves to (e.g. "/api/detect").
    *
-   * Creation-only and valid only for tunnel resources. Server validation
-   * rejects invalid paths, including paths missing a leading "/" or exceeding
-   * 2048 characters.
+   * Creation-only and valid only for tunnel resources. The SDK rejects empty
+   * or overlong values before sending a request; server validation rejects
+   * invalid path grammar, including paths missing a leading "/".
    */
   target_path?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -425,8 +425,9 @@ export type CreateQurlForResourceInput = Omit<
   /**
    * Path this resource qURL resolves to (e.g. "/api/detect").
    *
-   * Creation-only and valid only for tunnel resources. The API rejects invalid
-   * paths, including paths missing a leading "/" or exceeding 2048 characters.
+   * Creation-only and valid only for tunnel resources. Server validation
+   * rejects invalid paths, including paths missing a leading "/" or exceeding
+   * 2048 characters.
    */
   target_path?: string;
 };


### PR DESCRIPTION
## What

Adds `target_path` to `CreateQurlForResourceInput`, the input for
`createQurlForResource(id, input)` (POST `/v1/resources/:id/qurls`).

```ts
client.createQurlForResource("r_x", { target_path: "/api/detect" });
```

## Why

`target_path` is a **real, server-validated qURL API field** — it sets the
path a resource (tunnel) qURL resolves to (e.g. `/api/detect`). The server
owns its host-safety grammar and tunnel-only validation, returning
`invalid_target_path` on bad values. Until now the SDK rejected it client-side
because it wasn't in the `createQurlForResource` field allowlist
(`CREATE_QURL_FOR_RESOURCE_FIELD_KEYS`), so a valid field never reached the
wire.

The Discord bot needs `createQurlForResource(rid, { target_path: '/api/detect' })`
to mint a **detect-tunnel qURL** — this unblocks its detect-over-tunnel reach.

## Changes

- **`src/types.ts`** — extend `CreateQurlForResourceInput` with an optional
  `target_path?: string`. Scoped to the resource-qURL input only; **not**
  added to `CreateInput` (which would force it into the top-level `create()`
  allowlist and its `assertExhaustive`). The JSDoc calls out that the field is
  creation-only/tunnel-only, that the SDK rejects empty or overlong values
  pre-flight, and that path grammar stays server-validated.
- **`src/client.ts`** — add `"target_path"` to
  `CREATE_QURL_FOR_RESOURCE_FIELD_KEYS`. This satisfies both
  `requireNoUnknownFields` at runtime and the compile-time
  `assertExhaustive<keyof CreateQurlForResourceInput>` witness, and lets the
  field survive `normalizePatchFields` into the request body.
- **`validateQurlTokenOptions`** — reject empty `target_path` values and mirror
  the service-documented 2048-character size cap. Host-safety grammar
  (single leading slash, no scheme/host/backslash/etc.) and the tunnel-only
  gate remain server-authoritative via `invalid_target_path`.
- **`src/client.test.ts`** — five cases: (1) `target_path: "/api/detect"`
  does not throw an unknown-field error and is sent verbatim in the POST body
  to `/v1/resources/r_x/qurls`; (2) an empty `target_path` is rejected
  pre-flight as a `ValidationError`; (3) a `target_path` at the 2048-character
  service boundary, including the leading slash, is accepted and sent; (4) an
  overlong `target_path` is rejected pre-flight before any request is made;
  (5) a non-string `target_path` from an untyped caller is rejected pre-flight
  before any request is made.

## Versioning

No `package.json` version bump — versioning is intentionally left to
**Release Please**, which owns the `version` field in this repo. This `feat:`
commit drives the minor bump (to `0.3.0`) when RP cuts the release on merge.
`.release-please-manifest.json` likewise stays at the last released version.

## Verification

- `npm run build` (tsc ESM + CJS) — pass
- `npm test` (vitest) — 356 passed (incl. the 5 new `target_path` cases)
- `npm run lint` (eslint) — pass
- `npm run format:check` (prettier) — pass
- `npm run smoke:dist` — pass

The contract test / `openapi.snapshot.yaml` is `(verb, path)`-only and the
path is unchanged, so no contract change is required (that rule covers new
methods, not new fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
