### PR TITLE
test: consume qurl conformance vectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@layervai/qurl-conformance": "0.1.2",
         "@types/node": "^25.9.1",
         "@typescript-eslint/eslint-plugin": "^8.60.0",
         "@typescript-eslint/parser": "^8.58.2",
@@ -228,6 +229,13 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@layervai/qurl-conformance": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@layervai/qurl-conformance/-/qurl-conformance-0.1.2.tgz",
+      "integrity": "sha512-4fDXzXUq/Wu6DbDI2p1OvgN8h6Kw5nZtmfAECqneSCFbf/Iv9ypu08waPV1EK2wCD1YB8a/CzWeh8a58QEMzRQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@layervai/qurl-conformance": "0.1.2",
     "@types/node": "^25.9.1",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.58.2",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1356,10 +1356,14 @@ const MIN_PORTAL_VALID_FOR_SECONDS = 60;
  */
 const MIN_SESSION_DURATION_SECONDS = 1;
 
-// Shape of qurl-go's offline signed-fragment links: three or more
-// dot-separated base64url parts (<version>.<claims>.<secret>.<sig>).
-// Detected only to give those links a precise error in extractAccessToken.
-const SIGNED_FRAGMENT_RE = /^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2,}$/;
+/**
+ * Shape of qurl-go's offline signed-fragment links: three or more
+ * dot-separated base64url parts (<version>.<claims>.<secret>.<sig>).
+ * Detected only to give those links a precise error in extractAccessToken.
+ *
+ * @internal Exported for in-package tests; not re-exported from index.ts.
+ */
+export const SIGNED_FRAGMENT_RE = /^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){2,}$/;
 // Access-token grammar accepted by enterPortal (base64url charset).
 const ACCESS_TOKEN_RE = /^[A-Za-z0-9_-]+$/;
 

--- a/src/portal.test.ts
+++ b/src/portal.test.ts
@@ -1,10 +1,27 @@
 import { describe, it, expect, vi } from "vitest";
-import { ProtectedResource } from "./client.js";
+import conformancePackage from "@layervai/qurl-conformance";
+import { ProtectedResource, SIGNED_FRAGMENT_RE } from "./client.js";
 import { NotFoundError, QURLError, ValidationError } from "./errors.js";
 import { createClient, mockFetch, mockFetches } from "./__tests__/test-helpers.js";
 
 // Tests for the portal-verb surface (mirrors qurl-go's portal API and
 // qurl-python's port of it): protectUrl → createPortal → enterPortal.
+
+type Qv2ConformanceVector = {
+  name: string;
+  expect: "accept" | "reject";
+  fragment?: string;
+};
+
+type Qv2ConformanceFile = {
+  classes: Record<string, { vectors: Qv2ConformanceVector[] } | undefined>;
+};
+
+// Native ESM sees this CommonJS package on the default export. The package's
+// own types keep qv2Vectors() unknown, so narrow only the artifact fields read
+// by this test and keep runtime guards below.
+const conformance = conformancePackage as typeof import("@layervai/qurl-conformance");
+const MIN_CREDENTIAL_SEGMENT_LENGTH = 8;
 
 const RESOURCE_DATA = {
   resource_id: "r_abc123def45",
@@ -48,6 +65,18 @@ function callBody(fetch: typeof globalThis.fetch, index = 0): unknown {
 
 function callHeaders(fetch: typeof globalThis.fetch, index = 0): Record<string, string> {
   return callRequest(fetch, index).init.headers as Record<string, string>;
+}
+
+function conformanceFragment(name: string): string {
+  const artifact = conformance.qv2Vectors() as Qv2ConformanceFile;
+  const vector = (artifact.classes.fragment?.vectors ?? []).find((v) => v.name === name);
+  if (!vector || vector.expect !== "accept" || typeof vector.fragment !== "string") {
+    throw new Error(`qurl-conformance fragment vector ${name} is missing or not accept`);
+  }
+  if (!SIGNED_FRAGMENT_RE.test(vector.fragment)) {
+    throw new Error(`qurl-conformance fragment vector ${name} is not signed-fragment shaped`);
+  }
+  return vector.fragment;
 }
 
 describe("protectUrl", () => {
@@ -454,15 +483,26 @@ describe("enterPortal", () => {
 
   it("rejects qurl-go's offline signed-fragment links with a precise error, no echo", async () => {
     const client = createClient(mockFetch({ status: 200, body: { data: RESOLVE_DATA } }));
+    // This vector is `accept` for qurl-go's local verifier; this SDK's
+    // API-backed resolver rejects offline signed fragments before any request.
+    const signedFragment = conformanceFragment("accept_valid_fragment");
 
     const err = await client
-      .enterPortal("https://qurl.link/#v2.claimspart.secretpart.sigpart")
+      .enterPortal(`https://qurl.link/#${signedFragment}`)
       .catch((e: unknown) => e as ValidationError);
     expect((err as ValidationError).detail).toContain("signed qURL link");
-    expect((err as ValidationError).message).not.toContain("secretpart");
+    expect((err as ValidationError).message).not.toContain(signedFragment);
+    // Skip short framing/version pieces; these checks target credential-bearing segments.
+    const credentialSegments = signedFragment
+      .split(".")
+      .filter((segment) => segment.length >= MIN_CREDENTIAL_SEGMENT_LENGTH);
+    expect(credentialSegments.length).toBeGreaterThan(0);
+    for (const segment of credentialSegments) {
+      expect((err as ValidationError).message).not.toContain(segment);
+    }
 
     // A bare signed fragment (no link wrapper) is caught the same way.
-    await expect(client.enterPortal("v2.claimspart.secretpart.sigpart")).rejects.toMatchObject({
+    await expect(client.enterPortal(signedFragment)).rejects.toMatchObject({
       detail: expect.stringContaining("signed qURL link"),
     });
   });


### PR DESCRIPTION
## Summary

- add the published `@layervai/qurl-conformance` test dependency pinned exactly to `0.1.2`, matching the qurl-go conformance artifact version
- load the qv2 conformance artifact in the portal test suite and use the canonical `accept_valid_fragment` vector instead of a hand-rolled signed-fragment placeholder
- validate that the vector routes through the SDK signed-fragment guard and assert TypeScript rejects qurl-go offline links without echoing the full credential or credential-bearing segments

## Why

This keeps the TypeScript SDK portal-link behavior anchored to the shared qURL cross-language conformance artifact instead of a local placeholder string. That gives reviewers and downstream users stronger confidence that the SDK is staying aligned with the qurl-go wire contract where this SDK currently intersects it.

## Business relevance

qURL links are security-sensitive credentials. Using the same published conformance vectors as the Go SDK reduces cross-SDK drift risk and makes future protocol evolution easier to review, especially for customers adopting multiple qURL SDKs across services.

## Validation

- `npm ci --cache $(mktemp -d) --prefer-online`
- `npm run test`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run smoke:dist`
- GitHub checks: all non-quarantine checks are green on the latest SHA; `age-check / check-npm-dependency-age` is blocked by the 7-day npm quarantine for `@layervai/qurl-conformance@0.1.2` until 2026-07-08

## Current merge gate

Ready for review. The remaining merge gate is the npm dependency quarantine. The age-check workflow says `age-check-bypass` is for verified-CVE emergencies only, so this non-CVE dependency update should wait for quarantine to clear instead of bypassing policy. Follow-up: #165.