### PR TITLE
build(deps): bump github/codeql-action from 4.36.2 to 4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -42,6 +42,6 @@ jobs:
       # `javascript-typescript` and `actions` both use build-mode none, so no
       # explicit build step is required.
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Fixes the CodeQL build failures on #174.

Dependabot's #174 bumped **only** the `github/codeql-action/analyze` sub-action to 4.36.3, leaving `github/codeql-action/init` pinned at 4.36.2 in the same workflow. CodeQL requires `init` and `analyze` to run the **same** version, so both `Analyze` jobs failed with a configuration error:

```
Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

This PR bumps **both** `init` and `analyze` to the matching 4.36.3 pin (`54f647b`), so the versions align and CodeQL passes.

## Why the age-check also failed on #174

The `age-check / Check GitHub Actions pin ages` job (`min_age_days: 7`) failed on #174 because the 4.36.3 commit (`54f647b`, dated 2026-07-02) was only ~6 days old when that PR ran on 2026-07-08. The pin is now >7 days old, so the age gate passes.

## Supersedes

This is the complete version of the bump #174 attempted, so #174 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)