### PR TITLE
ci: bump codeql-action/analyze to v4.36.3 to match init

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -42,6 +42,6 @@ jobs:
       # `javascript-typescript` and `actions` both use build-mode none, so no
       # explicit build step is required.
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Bumps `github/codeql-action/analyze` to **v4.36.3** (`54f647b`) so it matches `github/codeql-action/init`, which was already bumped to v4.36.3 in #170.

## Why

Dependabot #170 bumped **only** `codeql-action/init` to v4.36.3 and left `codeql-action/analyze` pinned at v4.36.2. CodeQL requires every one of its action steps to run the **same version**, so the mismatch failed both Analyze jobs:

```
##[error]Loaded a configuration file for version '4.36.3', but running version '4.36.2'
```

This supersedes #170 — once this merges, `main` has codeql-action fully on v4.36.3 and Dependabot will auto-close #170 as resolved.

### About the third failing check on #170

The `age-check / Check GitHub Actions pin ages` failure on #170 was time-based, not a code problem:

```
github/codeql-action@54f647b7 committed 5 day(s) ago (minimum: 7; eligible after 2026-07-09)
```

The v4.36.3 commit (2026-07-02) was only 5 days old when #170 ran on 2026-07-08, below the 7-day quarantine. It is now past 7 days, so the check passes on a fresh run.

### Follow-up (not in this PR)

The root cause is that `.github/dependabot.yml` has no `groups` for github-actions, so `codeql-action/*` sub-actions get bumped in separate PRs. Grouping them would prevent this class of split-version failure.