### PR TITLE
ci: group codeql-action sub-actions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,20 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      # Keep all github/codeql-action/* sub-actions (init, analyze, autobuild,
+      # upload-sarif, ...) in one PR. They share one version/SHA and must be
+      # bumped together, or CodeQL Analyze fails with a version mismatch.
+      # A group defaults to applies-to: version-updates, so a second group
+      # covers security (CVE-driven) bumps too — otherwise a lone security
+      # bump of init/analyze could re-introduce the same mismatch.
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
+      codeql-action-security:
+        applies-to: security-updates
+        patterns:
+          - "github/codeql-action/*"
   - package-ecosystem: npm
     directory: /
     schedule:


### PR DESCRIPTION
## What

Add `codeql-action` groups to the `github-actions` ecosystem in [`.github/dependabot.yml`](.github/dependabot.yml) so every `github/codeql-action/*` sub-action (`init`, `analyze`, `autobuild`, `upload-sarif`, …) is bumped **together in a single PR** — for both regular version updates and security updates.

```yaml
groups:
  codeql-action:
    patterns:
      - "github/codeql-action/*"
  codeql-action-security:
    applies-to: security-updates
    patterns:
      - "github/codeql-action/*"
```

## Why

Dependabot treats `github/codeql-action/init` and `github/codeql-action/analyze` as **separate dependencies**. When a bump moves one and not the other, both CodeQL Analyze jobs fail with:

> Loaded a configuration file for version 'X', but running version 'Y'

This has happened **twice**: #170, and again in the #180 → #181 sequence on `main` (a codeql-action bump followed by a manual `analyze` bump to re-sync). The root cause — nothing keeping the co-versioned sub-actions in lockstep — persisted. This group is the durable fix: `init` and `analyze` (both currently `v4.36.3` / `54f647b` in [`.github/workflows/codeql.yml`](.github/workflows/codeql.yml)) move as one unit going forward.

**Two groups, not one.** A Dependabot group defaults to `applies-to: version-updates`. Without a mirrored `security-updates` group, a CVE-driven bump of just `init` (or just `analyze`) would still land as an individual PR and re-introduce the exact mismatch this PR fixes. The second group closes that hole. (Thanks to the review bot for catching this.)

## Pattern form

`github/codeql-action/*` (with the slash) is used deliberately. Verified against dependabot-core's actual matcher ([`WildcardMatcher.match?`](https://github.com/dependabot/dependabot-core/blob/main/common/lib/wildcard_matcher.rb)), which compiles `*` to regex `.*` (so it spans `/`): the pattern matches every current and future sub-action and excludes unrelated deps (`actions/checkout`, a bare `github/codeql`, etc.). The slash form exactly expresses "sub-actions under this path" and matches the in-file comment.

## Scope decision

Only `codeql-action` is grouped, not all github-actions. The lockstep requirement is specific to these hard-coupled sub-actions (same job, same CodeQL bundle, same SHA). The repo's other actions are independent single-path actions reviewed as individual PRs. The `layervai/ops-routines-workflows/*` reusable workflows are also multi-path but only *soft*-coupled (independent jobs, already harmlessly drifted) — consolidating those is PR-noise reduction, tracked separately in #183.

## Verification

- YAML parses; two distinct groups resolve to `patterns: ['github/codeql-action/*']` with correct `applies-to` (default version-updates + explicit security-updates).
- `applies-to: security-updates` validity confirmed against GitHub's Dependabot options reference.
- Pattern matching simulated against dependabot-core's `WildcardMatcher` — matches both sub-actions (and future ones), excludes unrelated deps.
- Dependabot's own config validator (the `.github/dependabot.yml` check) passes; `prettier --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)