### PR TITLE
build: migrate CJS build off the removed Node10 moduleResolution

### DIFF
--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,11 +2,14 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    // TODO: TS 7 will drop `Node10`. Migrate to `module: "Node16"` + a
-    // source-side CJS sidecar (or matching `.cts` entry) before then.
-    "moduleResolution": "Node10",
+    // `Bundler`, not the removed-in-TS-7 `Node10`. This CJS pass can't
+    // simply inherit the base config's `Node16` resolution — that would
+    // force `module: "Node16"` and emit ESM. `src/` imports already carry
+    // explicit `.js` extensions, so the resolution mode only affects
+    // type-checking here, not the CommonJS emit — the emitted `dist/cjs`
+    // is byte-identical to the prior `Node10` output.
+    "moduleResolution": "Bundler",
     "outDir": "./dist/cjs",
-    "ignoreDeprecations": "6.0",
     // The ESM tree already emits declaration + source maps from the same
     // `src/` tree; emitting them again into `dist/cjs/` doubles tarball
     // size for no additional signal. The ESM maps themselves ship but


### PR DESCRIPTION
## What

Switch the CJS build's `moduleResolution` from `Node10` to `Bundler` in `tsconfig.cjs.json`, and drop the now-unnecessary `ignoreDeprecations: "6.0"`. Resolves the standing TODO in that file.

## Why

TypeScript 7 **removes** the `Node10` moduleResolution option — `tsc -p tsconfig.cjs.json` fails hard with:

```
tsconfig.cjs.json(7,25): error TS5108: Option 'moduleResolution=node10' has been removed.
```

The config can't simply drop the option and inherit the base `tsconfig.json`, because that supplies `moduleResolution: "Node16"`, which requires `module: "Node16"` and would emit **ESM** into `dist/cjs`. `Bundler` resolution pairs cleanly with `module: "CommonJS"` and keeps the CommonJS emit.

Because `src/` imports already carry explicit `.js` extensions (the ESM build is already `Node16`), the resolution mode only affects type-checking — **not** the emit. I verified the emitted `dist/cjs` is **byte-identical** to the prior `Node10` output (diffing a full build under each config; the only delta is the `postbuild.mjs`-generated `package.json` sidecar).

## Verification

Full CI matrix, green under **both** compilers:

| Gate | TS 6.0.3 (this PR) | TS 7.0.2 (spike) |
|---|---|---|
| `npm ci` / build | ✅ | ✅ |
| `lint` | ✅ | ⚠️ blocked¹ |
| `format:check` | ✅ | ✅ |
| `test` (499) | ✅ | ✅ |
| `smoke:dist` (cjs/esm/parity/idempotency) | ✅ | ✅ |

¹ Not a regression in this PR — lint is green here on TS 6. Under TS 7, `@typescript-eslint` crashes independently (see below); this PR does not bump TypeScript.

## Context — relationship to #191

This is **Phase 0** of the TypeScript 7 migration. It's a standalone, no-op-at-runtime build cleanup that lands today on TS 6 and shrinks the eventual TS 7 diff to just version bumps.

It does **not** unblock Dependabot #191 (`bump typescript 6.0.3 → 7.0.2`). That remains blocked on `@typescript-eslint` shipping a release whose peer range includes `7.x` — the latest (`8.65.0`) still caps at `<6.1.0`, and `typescript-estree` crashes against TS 7's native-compiler API (`Cannot read properties of undefined (reading 'Cjs')`). Source code and tests already pass clean under TS 7, so once the linter is unblocked the bump should be mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
