### PR TITLE
build(deps): bump brace-expansion from 5.0.6 to 5.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1068,9 +1068,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

Bump the transitive `brace-expansion` from **5.0.6 → 5.0.7** (lockfile-only). Closes the repo's open Dependabot alert ([security/dependabot/1](https://github.com/layervai/qurl-typescript/security/dependabot/1)).

## Why

**GHSA-3jxr-9vmj-r5cp / CVE-2026-13149** (high) — DoS via exponential-time expansion of consecutive non-expanding `{}` groups. Vulnerable range `>=3.0.0 <5.0.7`; the lockfile pinned 5.0.6.

Dependency path: `eslint@10.6.0 → minimatch@10.2.4 → brace-expansion`. It's a **dev-only, transitive** dependency, so the published package is unaffected (`files: ["dist/"]` ships `dist/` only) — this hardens the toolchain, not the shipped SDK.

## Why 5.0.7 and not the latest 5.0.8

`5.0.8` was published 2026-07-23 (1 day ago) and would **fail** this repo's `min_age_days: 7` dependency-age check until ~07-30. `5.0.7` (published 2026-06-29) clears it. `.npmrc`'s `min-release-age=7` capped the resolve at 5.0.7 automatically — no manual pin, no `package.json` change.

## Verification

- `npm audit` → **found 0 vulnerabilities** (was 1 high)
- `npm ls brace-expansion` → single instance, now `5.0.7`
- Full matrix green: build · lint · format:check · test (499) · smoke:dist
- Diff is 3 lines (version / resolved / integrity); `package.json` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
