### PR TITLE
refactor(api)!: drop the retired agent bootstrap route

### DIFF
--- a/contract/openapi.snapshot.yaml
+++ b/contract/openapi.snapshot.yaml
@@ -16,8 +16,6 @@ info:
   title: QURL API — SDK contract surface
   version: "1"
 paths:
-  /v1/agent/bootstrap:
-    post: {}
   /v1/api-keys:
     get: {}
     post: {}

--- a/src/contract.test.ts
+++ b/src/contract.test.ts
@@ -46,9 +46,11 @@ for (const [path, methods] of Object.entries(spec.paths ?? {})) {
 // cutover removes it. It is intentionally absent from the shipped SDK and must
 // not be added back to METHOD_CASES. Delete this exception when the post-cutover
 // OpenAPI snapshot drops the route.
-const PRODUCER_ONLY_TEMPLATES: ReadonlySet<string> = new Set([
-  ["POST", ["/v1/agent/", "bootstrap"].join("")].join(" "),
-]);
+// Snapshot templates the SDK deliberately does not exercise. Empty since the
+// HTTP agent lifecycle was retired: the Connector enrolls over native UDP, so
+// the bootstrap route no longer exists upstream to except. The stale-exception
+// check below keeps this list from outliving the routes it covers.
+const PRODUCER_ONLY_TEMPLATES: ReadonlySet<string> = new Set([]);
 
 // Escape regex metacharacters in a literal string so it can be embedded
 // in a larger regex safely. The only caller is templateRegex below,


### PR DESCRIPTION
## What

Removes `POST /v1/agent/bootstrap` from `contract/openapi.snapshot.yaml`, and the now-stale `PRODUCER_ONLY_TEMPLATES` exception that covered it.

## Why

`src/client.ts` stopped calling that route when the Connector moved to native UDP enrollment. The snapshot is documented as hand-maintained **in lockstep with `client.ts`** — so it was simply stale, along with the test exception.

Not cosmetic: the UDP proof's orchestrator evidence collector reads this exact file and refuses to proceed while it exports a retired lifecycle marker.

```
layervai/qurl-typescript/contract/openapi.snapshot.yaml still exports
retired lifecycle surface markers ['/v1/agent/bootstrap']
```

That was blocking the sandbox UDP substrate proof's `post_removal` phase.

## The exception list did its job

Removing the route made `contract.test.ts` fail loudly and precisely:

```
Producer-only snapshot exception(s) no longer exist: POST /v1/agent/bootstrap.
Remove the exception now that the upstream route is gone.
```

So `PRODUCER_ONLY_TEMPLATES` becomes **empty** rather than gaining a replacement entry — its own stale-exception check is what caught the leftover.

Worth noting the entry was written as `["/v1/agent/", "bootstrap"].join("")` specifically so the literal never appears in source and trips the retirement marker scan. That deliberate obfuscation is no longer needed.

## Tests

415 passed, 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)